### PR TITLE
Limiting cores used for extraction QL

### DIFF
--- a/llamas_pyjamas/GUI/guiExtract.py
+++ b/llamas_pyjamas/GUI/guiExtract.py
@@ -116,7 +116,7 @@ def match_hdu_to_traces(hdu_list, trace_files):
     return matches
 
 # Define a Ray remote function for processing a single trace extraction.
-@ray.remote
+@ray.remote(num_cpus=5)
 def process_trace(hdu_data, header, trace_file):
     """
     Process a single HDU: subtract bias, load the trace from a trace file, and create an ExtractLlamas object.


### PR DESCRIPTION
Manual set number of cores the extraction process uses to 5 to prevent llamas1 being overloaded. This can be easily overwritten by changing or removing the value supplied in @ray.remote(num_cpus=5) on line 119 in guiextract.py.