### PR TITLE
Image reconstruction mapping fixes to improve tracing, insert dead fibres appropriately, and use new skyflats for Blue alignment changes.

### DIFF
--- a/llamas_pyjamas/GUI/guiExtract.py
+++ b/llamas_pyjamas/GUI/guiExtract.py
@@ -22,6 +22,8 @@ from llamas_pyjamas.Extract.extractLlamas import ExtractLlamas, save_extractions
 from llamas_pyjamas.Image.WhiteLight import WhiteLight, WhiteLightFits, WhiteLightQuickLook
 import time
 
+from llamas_pyjamas.File.llamasIO import process_fits_by_color
+
 # Set up logging
 timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
 logger = setup_logger(__name__, log_filename=f'extractLlamas_{timestamp}.log')
@@ -33,7 +35,8 @@ logger = setup_logger(__name__, log_filename=f'extractLlamas_{timestamp}.log')
 def ExtractLlamasCube(infits, tracefits, optimal=True):
 
     assert infits.endswith('.fits'), 'File must be a .fits file'  
-    hdu = fits.open(infits)
+    # hdu = fits.open(infits)
+    hdu = process_fits_by_color(infits)
 
     # Find the trace files
     basefile = os.path.basename(tracefits).split('.fits')[0]
@@ -222,7 +225,7 @@ def GUI_extract(file: fits.BinTableHDU, flatfiles: str = None, bias: str = None)
         ray.init(num_cpus=num_cpus, runtime_env=runtime_env)
 
         #opening the fitsfile
-        hdu = fits.open(file)
+        hdu = process_fits_by_color(file)
 
         
 
@@ -351,7 +354,7 @@ def box_extract(file, flat=False):
         ray.init(runtime_env=runtime_env)
 
         #opening the fitsfile
-        hdu = fits.open(file)
+        hdu = process_fits_by_color(file)
 
         #Defining the base filename
         basefile = os.path.basename(file).split('.fits')[0]

--- a/llamas_pyjamas/Image/WhiteLight.py
+++ b/llamas_pyjamas/Image/WhiteLight.py
@@ -226,7 +226,7 @@ def WhiteLight(extraction_array: list, metadata: list, ds9plot=True)-> Tuple[np.
     x_grid, y_grid = np.meshgrid(xx, yy)
     
     whitelight = flux_interpolator(x_grid, y_grid)
-    whitelight = np.fliplr(whitelight)
+    # whitelight = np.fliplr(whitelight)
     if (ds9plot):
         #ds9 = pyds9.DS9(target='DS9:*', start=True, wait=10, verify=True)
         #ds9.set_np2arr(whitelight)

--- a/llamas_pyjamas/Image/WhiteLight.py
+++ b/llamas_pyjamas/Image/WhiteLight.py
@@ -179,8 +179,8 @@ def WhiteLight(extraction_array: list, metadata: list, ds9plot=True)-> Tuple[np.
         side = meta['side']
         counts = extraction_obj.counts
         #Might need to put in side condition here as well it depends on the outcome
-        if channel == 'blue':
-            counts = np.flipud(extraction_obj.counts)
+        # if channel == 'blue':
+        #     counts = np.flipud(extraction_obj.counts)
     
         if isinstance(extraction_obj, str):
             extraction, _ = ExtractLlamas.loadExtraction(extraction_obj)

--- a/llamas_pyjamas/Trace/traceLlamasMaster.py
+++ b/llamas_pyjamas/Trace/traceLlamasMaster.py
@@ -182,6 +182,12 @@ class TraceLlamas:
         self.window = 5 #can update to 15
         self.offset_cutoff = 3
         
+        with open(os.path.join(LUT_DIR, 'traceLUT.json'), 'r') as f:
+                LUT = json.load(f)
+                self.LUT = LUT
+        
+        self.dead_fibres = LUT['dead_fibers']
+        
 
         # 1A    298 (Green) / 298 Blue
         # 1B    300 (Green) / 300 Blue
@@ -550,6 +556,55 @@ class TraceLlamas:
             #interpolates the traces to give an x,y position for each fiber along the naxis
             
             self.traces = pydl.traceset2xy(self.tset,xpos=x2)[1]
+            
+            
+            # Filter traces to match expected fiber count
+            fiber_list = {
+                '1A': 298, '1B': 300, '2A': 298, 
+                '2B': 297, '3A': 298, '3B': 300, '4A': 300
+            }
+            expected_count = fiber_list.get(self.benchside)
+            
+            if expected_count and len(self.traces) > expected_count:
+                logger.info(f"Found {len(self.traces)} traces, limiting to expected {expected_count} for {self.benchside}")
+                
+                # Calculate edge proximity scores for each trace
+                # Lower score = further from edge = better
+                edge_scores = np.zeros(len(self.traces))
+                
+                # Get the middle position of each trace (at center of detector)
+                mid_x = self.naxis1 // 2
+                mid_positions = self.traces[:, mid_x]
+                
+                # Calculate distance from edges
+                for i, pos in enumerate(mid_positions):
+                    # Distance from top and bottom edges
+                    dist_from_top = pos
+                    dist_from_bottom = self.naxis2 - pos
+                    
+                    # Use minimum distance to either edge as score
+                    edge_scores[i] = min(dist_from_top, dist_from_bottom)
+
+                # Sort traces by distance from edge (descending)
+                # This keeps traces furthest from edges
+                sorted_indices = np.argsort(edge_scores)[::-1]
+                
+                # Keep only the expected number of traces
+                keep_indices = sorted_indices[:expected_count]
+                keep_indices.sort()  # Sort back to original order
+                
+                # Filter the traces
+                self.traces = self.traces[keep_indices]
+                
+                # Update other related arrays to match
+                self.tracearr = self.tracearr[keep_indices]
+                self.xtracefit = self.xtracefit[keep_indices]
+                self.nfibers = len(self.traces)
+                
+                logger.info(f"Filtered to {self.nfibers} traces for {self.benchside}")
+                
+            
+            
 
 
         except Exception as e:
@@ -638,9 +693,17 @@ class TraceLlamas:
         
         return (fiberimg, profimg, bpmask)
     
-    def saveTraces(self, outfile='LLAMASTrace.pkl')-> None:
-        os.makedirs(CALIB_DIR, exist_ok=True)
-        outpath = os.path.join(CALIB_DIR, outfile)
+    def saveTraces(self, outfile='LLAMASTrace.pkl', newpath=None)-> None:
+        
+        
+        if newpath:
+            print(f'Making directory newpath: {newpath}')   
+            path = os.path.dirname(newpath)
+            os.makedirs(path, exist_ok=True)
+            outpath = outpath = os.path.join(newpath, outfile)
+        else:
+            os.makedirs(CALIB_DIR, exist_ok=True)
+            outpath = os.path.join(CALIB_DIR, outfile)
         
             
         print(f'outpath: {outpath}')
@@ -684,7 +747,7 @@ class TraceRay(TraceLlamas):
         return
     
     
-    def process_hdu_data(self, hdu_data: np.ndarray, hdu_header: dict) -> dict:
+    def process_hdu_data(self, hdu_data: np.ndarray, hdu_header: dict, outpath=None) -> dict:
         start_time = time.time()
         
         result = super().process_hdu_data(hdu_data, hdu_header)
@@ -695,9 +758,19 @@ class TraceRay(TraceLlamas):
         origfile = self.fitsfile.split('.fits')[0]
         color = self.channel.lower()
         print(f'color: {color}')
-        self.outfile = f'LLAMAS_master_{self.channel.lower()}_{self.bench}_{self.side}_traces.pkl'
-        print(f'outfile: {self.outfile}')
-        super().saveTraces(self.outfile)
+        
+        filename = f'LLAMAS_master_{self.channel.lower()}_{self.bench}_{self.side}_traces.pkl'
+        
+        if outpath:
+            os.makedirs(outpath, exist_ok=True)
+            super().saveTraces(filename, newpath=outpath)
+        else:
+            super().saveTraces(filename)
+        
+        
+        
+        
+            
         
         elapsed_time = time.time() - start_time
         return 
@@ -768,6 +841,7 @@ if __name__ == "__main__":
     parser.add_argument('filename', type=str, help='Path to input FITS file')
     parser.add_argument('--mastercalib', action='store_true', help='Use master calibration')
     parser.add_argument('--channel', type=str, choices=['red', 'green', 'blue'], help='Specify the color channel to use')
+    parser.add_argument('--outpath', type=str, help='Path to save output files')
     args = parser.parse_args()
       
     NUMBER_OF_CORES = multiprocessing.cpu_count() 
@@ -798,7 +872,7 @@ if __name__ == "__main__":
     #hdu_processor = TraceRay.remote(fitsfile)
         
     for index, ((hdu_data, hdu_header), processor) in enumerate(zip(hdus, hdu_processors)):
-        future = processor.process_hdu_data.remote(hdu_data, hdu_header)
+        future = processor.process_hdu_data.remote(hdu_data, hdu_header, outpath=args.outpath)
         futures.append(future)
     
     # Monitor processing

--- a/llamas_pyjamas/Trace/traceLlamasMulti.py
+++ b/llamas_pyjamas/Trace/traceLlamasMulti.py
@@ -49,6 +49,7 @@ import pkg_resources
 from pathlib import Path
 import rpdb
 
+from llamas_pyjamas.File.llamasIO import process_fits_by_color
 
 # Enable DEBUG for your specific logger
 logger = logging.getLogger(__name__)
@@ -737,8 +738,9 @@ def run_ray_tracing(fitsfile: str) -> None:
     futures = []
     results = []    
     
-    with fits.open(fitsfile) as hdul:
-        hdus = [(hdu.data.astype(float), dict(hdu.header)) for hdu in hdul[1:] if hdu.data.astype(float) is not None]
+    # with fits.open(fitsfile) as hdul:
+    hdul = process_fits_by_color(fitsfile)
+    hdus = [(hdu.data.astype(float), dict(hdu.header)) for hdu in hdul[1:] if hdu.data.astype(float) is not None]
         
     hdu_processors = [TraceRay.remote(fitsfile) for _ in range(len(hdus))]
     print(f"\nProcessing {len(hdus)} HDUs with {NUMBER_OF_CORES} cores")
@@ -798,13 +800,15 @@ if __name__ == "__main__":
     
     fitsfile = args.filename
 
-    with fits.open(fitsfile) as hdul:
-        if args.channel is not None and 'COLOR' in hdul[1].header:
-            hdus = [(hdu.data.astype(float), dict(hdu.header)) for hdu in hdul if hdu.data is not None and hdu.header['COLOR'].lower() == args.channel.lower()]
-        elif args.channel is not None and 'CAM_NAME' in hdul[1].header:
-            hdus = [(hdu.data.astype(float), dict(hdu.header)) for hdu in hdul if hdu.data is not None and hdu.header['CAM_NAME'].split('_')[1].lower() == args.channel.lower()]
-        else:
-            hdus = [(hdu.data.astype(float), dict(hdu.header)) for hdu in hdul if hdu.data is not None]
+    # with fits.open(fitsfile) as hdul:
+    hdul = process_fits_by_color(fitsfile)
+    
+    if args.channel is not None and 'COLOR' in hdul[1].header:
+        hdus = [(hdu.data.astype(float), dict(hdu.header)) for hdu in hdul if hdu.data is not None and hdu.header['COLOR'].lower() == args.channel.lower()]
+    elif args.channel is not None and 'CAM_NAME' in hdul[1].header:
+        hdus = [(hdu.data.astype(float), dict(hdu.header)) for hdu in hdul if hdu.data is not None and hdu.header['CAM_NAME'].split('_')[1].lower() == args.channel.lower()]
+    else:
+        hdus = [(hdu.data.astype(float), dict(hdu.header)) for hdu in hdul if hdu.data is not None]
 
 
 

--- a/llamas_pyjamas/Utils/utils.py
+++ b/llamas_pyjamas/Utils/utils.py
@@ -396,3 +396,54 @@ def count_trace_fibres(mastercalib_dir: str = CALIB_DIR)-> None:
         benchside = traceobj.benchside
         req = N_fib[benchside]
         print(f'Channel {channel} Benchside {benchside} trace has {shape} fibres and requires {req}')
+        
+        
+def flip_blue_combs()-> None:
+    """
+    Flips all blue combs in the lookup table (LUT) file.
+    
+    This function reads the LUT JSON file, processes all benchsides ('1A' through '4B')
+    in the blue combs section, and flips those comb arrays. The updated LUT is then 
+    saved back to the JSON file.
+    
+    The function performs the following steps:
+    1. Loads the LUT from 'LUT/traceLUT.json'.
+    2. Checks if 'combs' and 'blue' keys exist in the LUT structure.
+    3. For each benchside (1A-4B) in the blue combs, flips the comb array.
+    4. Saves the updated LUT back to the original file.
+    
+    Raises:
+        FileNotFoundError: If the LUT file does not exist.
+        json.JSONDecodeError: If the LUT file is not a valid JSON.
+        KeyError: If the expected structure ('combs' > 'blue') is not found.
+    """
+    # Load LUT
+    with open('LUT/traceLUT.json', 'r') as f:
+        lut = json.load(f)
+    
+    # Check if 'combs' and 'blue' keys exist
+    if 'combs' not in lut:
+        print("Combs data not found in LUT")
+        return
+        
+    if 'blue' not in lut['combs']:
+        print("Blue comb data not found in LUT")
+        return
+    
+    # Process each benchside for blue combs
+    for benchside in lut['combs']['blue'].keys():
+        # Get the comb as a list
+        comb = lut['combs']['blue'][benchside]
+        
+        # Flip the comb array
+        flipped_comb = list(reversed(comb))
+        
+        # Replace the original comb with the flipped one
+        lut['combs']['blue'][benchside] = flipped_comb
+        print(f"Flipped blue comb for benchside {benchside}")
+    
+    # Save the updated LUT
+    with open('LUT/traceLUT.json', 'w') as f:
+        json.dump(lut, f, indent=4)
+    
+    print("Blue combs successfully flipped and saved to LUT/traceLUT.json")


### PR DESCRIPTION
- Traces can now be written to a given output path
- Traces now exclude additional problematic traces near the edge of the image
- FileIO now does the appropriate flips to the image data
- Whitelight has had redundant flip removed
- Extract inserts a dummy array of zeros at the appropriate locations for the dead fibres