### PR TITLE
Pipeline resume, edge-bias DC correction, and reduction setup GUI

### DIFF
--- a/llamas_pyjamas/Bias/biasChecking.py
+++ b/llamas_pyjamas/Bias/biasChecking.py
@@ -18,6 +18,7 @@ repeated calls with the same tracer object.
 import logging
 import numpy as np
 import scipy.ndimage
+from astropy.stats import sigma_clipped_stats
 from dataclasses import dataclass, field
 from typing import List, Dict, Optional, Tuple
 
@@ -143,6 +144,118 @@ def build_interfibre_mask(tracer,
         f"{gap_mask.sum()} gap pixels ({100*gap_mask.mean():.1f}%)"
     )
     return gap_mask
+
+
+# ---------------------------------------------------------------------------
+# Edge-bias (per-frame DC offset) support
+# ---------------------------------------------------------------------------
+
+def build_topbottom_stripe_mask(tracer,
+                                image_shape: Tuple[int, int],
+                                min_distance: float = 20.0) -> np.ndarray:
+    """
+    Build a boolean mask of unilluminated pixels that lie far from any fibre.
+
+    LLAMAS traces span the full dispersion (X) range, so the pixels that are
+    farther than ``min_distance`` from every fibre are the top/bottom stripes
+    *outside* the fibre stack (above the top trace / below the bottom trace).
+    Unlike inter-fibre gaps these carry no sky, so the level measured over this
+    mask is a clean per-extension bias reference even on science frames.
+
+    Uses the ``fiberimg`` attribute of a loaded ``TraceLlamas`` object (fibre
+    pixels are >= 0; non-fibre pixels are -1). A Euclidean distance transform
+    gives, at each non-fibre pixel, the distance to the nearest fibre pixel.
+
+    The result is cached in ``_MASK_CACHE`` keyed on
+    ``(id(tracer), 'stripe', min_distance)``.
+
+    Parameters
+    ----------
+    tracer : TraceLlamas or None
+        Loaded trace object with a ``fiberimg`` attribute. If unavailable, an
+        all-False mask is returned (caller then skips the correction).
+    image_shape : (int, int)
+        (n_rows, n_cols) of the detector image.
+    min_distance : float
+        Minimum distance (pixels) from any fibre for a pixel to count as an
+        unilluminated stripe pixel.
+
+    Returns
+    -------
+    numpy.ndarray
+        Boolean array of shape ``image_shape`` where True = stripe pixel.
+    """
+    if tracer is None or not hasattr(tracer, 'fiberimg') or tracer.fiberimg is None:
+        logger.warning(
+            "build_topbottom_stripe_mask: tracer unavailable or lacks fiberimg; "
+            "returning empty mask"
+        )
+        return np.zeros(image_shape, dtype=bool)
+
+    cache_key = (id(tracer), 'stripe', float(min_distance))
+    if cache_key in _MASK_CACHE:
+        logger.debug(f"build_topbottom_stripe_mask: cache hit for {cache_key}")
+        return _MASK_CACHE[cache_key]
+
+    fibre_px = tracer.fiberimg >= 0
+    # distance_transform_edt returns, for each True pixel, the distance to the
+    # nearest False pixel. Passing ~fibre_px makes fibre pixels the False set, so
+    # each non-fibre pixel gets its distance to the nearest fibre.
+    dist = scipy.ndimage.distance_transform_edt(~fibre_px)
+    mask = dist > float(min_distance)
+
+    _MASK_CACHE[cache_key] = mask
+    logger.debug(
+        f"build_topbottom_stripe_mask: {int(mask.sum())} px > {min_distance}px "
+        f"from fibres ({100*mask.mean():.1f}%)"
+    )
+    return mask
+
+
+def measure_edge_dc_offset(data: np.ndarray,
+                           mask: np.ndarray,
+                           min_pixels: int = 500) -> Tuple[float, int, str]:
+    """
+    Measure a robust per-extension DC offset from unilluminated pixels.
+
+    Computes a sigma-clipped (σ=3) median of ``data`` over ``mask``. This is the
+    residual bias level to subtract from the whole frame (measured *after* master
+    bias subtraction, so it captures the nightly DC drift the static master bias
+    misses).
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        2-D frame (already master-bias-subtracted).
+    mask : numpy.ndarray
+        Boolean mask of unilluminated pixels (same shape as ``data``).
+    min_pixels : int
+        Minimum number of mask pixels required. Below this — or when the masked
+        data is constant (a placeholder extension) — no correction is made.
+
+    Returns
+    -------
+    (offset, n_pixels, source) : (float, int, str)
+        ``offset`` is the DC level (DN) to subtract, or 0.0 when skipped.
+        ``source`` is ``'ok'`` or ``'skipped'``.
+    """
+    data = np.asarray(data, dtype=np.float64)
+    n = int(np.count_nonzero(mask))
+    if n < int(min_pixels):
+        logger.warning(
+            f"measure_edge_dc_offset: only {n} mask pixels (< {min_pixels}); "
+            f"skipping edge-bias correction"
+        )
+        return 0.0, n, 'skipped'
+
+    vals = data[mask]
+    # Constant masked data => placeholder extension; nothing meaningful to subtract.
+    if np.nanmin(vals) == np.nanmax(vals):
+        logger.info("measure_edge_dc_offset: constant masked data (placeholder?); skipping")
+        return 0.0, n, 'skipped'
+
+    _, median, _ = sigma_clipped_stats(vals, sigma=3, maxiters=5)
+    return float(median), n, 'ok'
 
 
 # ---------------------------------------------------------------------------

--- a/llamas_pyjamas/Flat/fibreFlat.py
+++ b/llamas_pyjamas/Flat/fibreFlat.py
@@ -322,7 +322,7 @@ def compute_fibre_flat_lamp_only(smooth_models_file, output_dir):
 # ──────────────────────────────────────────────────────────────────────────────
 
 def reduce_twilight_flat(twilight_file, p2p_map_file, trace_dir, arc_soln,
-                         slow_bias, output_dir, fast_bias=None):
+                         slow_bias, output_dir, fast_bias=None, edge_bias=None):
     """Reduce a twilight flat: bias/P2P correct, extract, wavelength calibrate.
 
     Reuses existing pipeline infrastructure for each step.
@@ -370,7 +370,7 @@ def reduce_twilight_flat(twilight_file, p2p_map_file, trace_dir, arc_soln,
     extraction_file = run_extraction(
         corrected_file, twi_output_dir,
         slow_bias=slow_bias, fast_bias=fast_bias, trace_dir=trace_dir,
-        remove_cosmic_rays=False)
+        remove_cosmic_rays=False, edge_bias=edge_bias)
     logger.info(f"Twilight extraction: {extraction_file}")
 
     # Step 3: Wavelength calibration

--- a/llamas_pyjamas/Flat/flatLlamas.py
+++ b/llamas_pyjamas/Flat/flatLlamas.py
@@ -748,12 +748,69 @@ def _write_smooth_models_fits(all_smooth_data, output_path, filter_size=51,
                 f"({len(hdul) - 1} extensions)")
 
 
+def _build_flat_unillum_mask(ext_obj, smooth_models, unillum_frac=0.1):
+    """2-D boolean mask of on-fibre pixels that are unilluminated in the flat.
+
+    For each fibre, columns where the smooth flat model falls below
+    ``unillum_frac`` of that fibre's own peak are 'dark' (dichroic crossover /
+    low-sensitivity ends). Mapped back to 2-D via the tracer ``fiberimg``, giving
+    the per-pixel, y-dependent unilluminated mask used by edge-bias Tier 2.
+    Returns None if the tracer/fiberimg is unavailable.
+    """
+    trace = getattr(ext_obj, 'trace', None)
+    fiberimg = getattr(trace, 'fiberimg', None) if trace is not None else None
+    if fiberimg is None:
+        return None
+    ny, nx = fiberimg.shape
+    mask = np.zeros((ny, nx), dtype=bool)
+    for fid, sm in (smooth_models or {}).items():
+        sm = np.asarray(sm, dtype=float).ravel()
+        if sm.size == 0:
+            continue
+        peak = np.nanmax(sm)
+        if not np.isfinite(peak) or peak <= 0:
+            continue
+        col_dark = np.zeros(nx, dtype=bool)
+        n = min(nx, sm.size)
+        col_dark[:n] = sm[:n] < (unillum_frac * peak)
+        if not col_dark.any():
+            continue
+        mask |= (fiberimg == fid) & col_dark[np.newaxis, :]
+    return mask
+
+
+def _write_unillum_mask_fits(unillum_masks, path, unillum_frac):
+    """Write a boolean unilluminated-mask MEF keyed by camera.
+
+    One ImageHDU per detector holds a uint8 mask (1 = unilluminated on-fibre
+    pixel), tagged with BENCH/SIDE/COLOR so guiExtract._load_unillum_mask can
+    match it to a science detector.
+    """
+    from astropy.io import fits
+    primary = fits.PrimaryHDU()
+    primary.header['UNILFRAC'] = (float(unillum_frac),
+                                  'Flat frac below which pixel is dark')
+    hdus = [primary]
+    for ext_name, info in unillum_masks.items():
+        m = info.get('mask')
+        if m is None:
+            continue
+        hdu = fits.ImageHDU(data=m.astype(np.uint8), name=ext_name)
+        hdu.header['COLOR']   = str(info['channel'])
+        hdu.header['BENCH']   = str(info['bench'])
+        hdu.header['SIDE']    = str(info['side'])
+        hdu.header['EXTNAME'] = ext_name
+        hdu.header['NDARK']   = (int(m.sum()), 'Unilluminated on-fibre pixel count')
+        hdus.append(hdu)
+    fits.HDUList(hdus).writeto(path, overwrite=True)
+
+
 def process_pixel_flat_simple(red_flat_file, green_flat_file, blue_flat_file,
                               arc_calib_file=None, use_bias=None,
                               output_dir=OUTPUT_DIR, trace_dir=CALIB_DIR,
                               verbose=False, filter_size=12,
                               signal_thresholds=None, clip_range=(0.90, 1.10),
-                              saturation_threshold=None):
+                              saturation_threshold=None, unillum_frac=0.1):
     """Generate pixel-to-pixel sensitivity maps using the simple median+Gaussian method.
 
     Workflow:
@@ -892,6 +949,7 @@ def process_pixel_flat_simple(red_flat_file, green_flat_file, blue_flat_file,
 
     pixel_maps = {}  # keyed by underscore-separated ext_name
     all_smooth_data = {}  # keyed by ext_name, for fibre flat
+    unillum_masks = {}  # keyed by ext_name, for edge-bias Tier 2 (flat-derived L/R darks)
 
     for ext_idx, (ext_obj, meta) in enumerate(zip(extractions, metadata)):
         channel = meta['channel']
@@ -921,6 +979,18 @@ def process_pixel_flat_simple(red_flat_file, green_flat_file, blue_flat_file,
             return_smooth_models=True,
         )
         pixel_maps[ext_name] = pixel_map
+
+        # Edge-bias Tier 2: build the flat-derived unilluminated mask for this
+        # detector. On-fibre pixels whose smooth flat model drops below
+        # ``unillum_frac`` of that fibre's own peak are the dichroic-crossover /
+        # low-sensitivity dark zones (per-pixel, y-dependent). Never raises.
+        try:
+            unillum_masks[ext_name] = {
+                'mask': _build_flat_unillum_mask(ext_obj, smooth_models, unillum_frac),
+                'channel': channel, 'bench': bench, 'side': side,
+            }
+        except Exception as _um_exc:
+            logger.warning(f"  {ext_name}: unillum mask build failed ({_um_exc})")
 
         # Build FIBER_ID list keyed by physical ID, excluding dead fibres
         dead_set = set(getattr(ext_obj, 'dead_fibers', []) or [])
@@ -962,6 +1032,16 @@ def process_pixel_flat_simple(red_flat_file, green_flat_file, blue_flat_file,
     smooth_models_path = os.path.join(output_dir, 'flat_smooth_models.fits')
     _write_smooth_models_fits(all_smooth_data, smooth_models_path,
                               filter_size=filter_size)
+
+    # ── Step 7: Write flat-derived unilluminated mask (edge-bias Tier 2) ──
+    logger.info("Step 7: Writing flat-derived unilluminated mask FITS")
+    unillum_mask_path = os.path.join(output_dir, 'unillum_mask.fits')
+    try:
+        _write_unillum_mask_fits(unillum_masks, unillum_mask_path, unillum_frac)
+        logger.info(f"Unilluminated mask saved to: {unillum_mask_path}")
+    except Exception as _um_exc:
+        logger.warning(f"Failed to write unillum_mask.fits ({_um_exc}); "
+                       f"edge-bias Tier 2 will fall back to stripes only")
 
     logger.info(f"Pixel flat processing complete: {pixel_map_path}")
     logger.info(f"Smooth models saved to: {smooth_models_path}")

--- a/llamas_pyjamas/GUI/guiExtract.py
+++ b/llamas_pyjamas/GUI/guiExtract.py
@@ -30,7 +30,9 @@ import time
 from llamas_pyjamas.File.llamasIO import process_fits_by_color
 from llamas_pyjamas.DataModel.validate import get_placeholder_extension_indices, validate_for_gui
 from llamas_pyjamas.Bias import BiasNotFoundError, BiasReadModeError, generate_fallback_bias_hdu
-from llamas_pyjamas.Bias.biasChecking import build_interfibre_mask
+from llamas_pyjamas.Bias.biasChecking import (build_interfibre_mask,
+                                              build_topbottom_stripe_mask,
+                                              measure_edge_dc_offset)
 from llamas_pyjamas.Masking.cosmicLlamas import clean_cosmic_rays, save_cosmic_ray_masks
 
 # Set up logging
@@ -170,8 +172,132 @@ def match_hdu_to_traces(hdu_list, trace_files, start_idx=1):
 # permanently unschedulable. Concurrency is governed by `num_cpus` instead. To opt
 # back into a reservation on low-RAM machines, set `ray_task_memory_mb` in the
 # config (applied via `.options(memory=...)` at dispatch).
+def _load_unillum_mask(mask_dir, bench, side, color, shape):
+    """Load the per-camera flat-derived unilluminated mask extension, or None.
+
+    Looks for ``unillum_mask.fits`` in ``mask_dir`` (written by the flat stage)
+    and returns the boolean 2-D mask whose BENCH/SIDE/COLOR match this detector.
+    """
+    if not mask_dir:
+        return None
+    path = os.path.join(mask_dir, 'unillum_mask.fits')
+    if not os.path.exists(path):
+        return None
+    try:
+        with fits.open(path) as hml:
+            for h in hml[1:]:
+                hh = h.header
+                if (str(hh.get('BENCH', '')).strip() == str(bench)
+                        and str(hh.get('SIDE', '')).strip().upper() == str(side).upper()
+                        and str(hh.get('COLOR', '')).strip().lower() == str(color).lower()):
+                    if h.data is None:
+                        return None
+                    m = np.asarray(h.data).astype(bool)
+                    return m if m.shape == tuple(shape) else None
+    except Exception as exc:
+        logger.warning(f"_load_unillum_mask: failed to read {path}: {exc}")
+    return None
+
+
+def _apply_edge_bias(data, tracer, header, bench, side, color, edge_bias):
+    """Measure and subtract a per-extension DC offset from unilluminated pixels.
+
+    Runs *after* master-bias subtraction so it captures the residual nightly DC
+    drift the static master bias misses. The mask is the top/bottom stripes
+    outside the fibre stack (always), optionally unioned with a flat-derived
+    per-pixel dark mask (Tier 2). Writes EDGE* header keywords and returns
+    ``(corrected_data, stats_dict)``. The ``stats_dict`` also carries the
+    stripes-only and stripes+flat candidate levels for QA comparison.
+    """
+    eb = edge_bias or {}
+    dmin = float(eb.get('min_distance', 20.0))
+    min_px = int(eb.get('min_pixels', 500))
+    stats = {'edge_dc': 0.0, 'edge_npix': 0, 'edge_dmin': dmin, 'edge_src': 'disabled',
+             'level_stripes': float('nan'), 'level_combined': float('nan'),
+             'bench': bench, 'side': side, 'color': color}
+
+    if not eb.get('enabled', True):
+        header['EDGEDC']   = (0.0, 'Edge-bias DC offset subtracted (DN)')
+        header['EDGENPIX'] = (0, 'Edge-bias mask pixel count')
+        header['EDGEDMIN'] = (dmin, 'Edge-bias min distance from fibre (px)')
+        header['EDGESRC']  = ('disabled', 'Edge-bias mask source')
+        return data, stats
+
+    stripe_mask = build_topbottom_stripe_mask(tracer, data.shape, min_distance=dmin)
+    lvl_s, n_s, st_s = measure_edge_dc_offset(data, stripe_mask, min_pixels=min_px)
+    stats['level_stripes'] = lvl_s if st_s == 'ok' else float('nan')
+
+    chosen_lvl, chosen_n, chosen_st, src = lvl_s, n_s, st_s, 'stripes'
+
+    # Tier 2: optionally union with the flat-derived L/R dark zones.
+    if eb.get('use_flat_mask', False):
+        flat_mask = _load_unillum_mask(eb.get('flat_mask_dir'), bench, side, color, data.shape)
+        if (flat_mask is not None and hasattr(tracer, 'fiberimg')
+                and tracer.fiberimg is not None):
+            onfib = tracer.fiberimg >= 0
+            combined = stripe_mask | (onfib & flat_mask)
+            lvl_c, n_c, st_c = measure_edge_dc_offset(data, combined, min_pixels=min_px)
+            stats['level_combined'] = lvl_c if st_c == 'ok' else float('nan')
+            chosen_lvl, chosen_n, chosen_st, src = lvl_c, n_c, st_c, 'stripes+flat'
+        else:
+            logger.info(
+                f"Edge-bias: flat mask requested but unavailable for "
+                f"{bench}{side} {color}; using stripes only")
+
+    if chosen_st == 'ok':
+        corrected = data - chosen_lvl
+        edge_dc, edge_src = float(chosen_lvl), src
+    else:
+        corrected = data
+        edge_dc, edge_src = 0.0, ('skipped_placeholder' if chosen_n > 0 else 'skipped')
+
+    stats.update(edge_dc=edge_dc, edge_npix=int(chosen_n), edge_src=edge_src)
+    header['EDGEDC']   = (edge_dc, 'Edge-bias DC offset subtracted (DN)')
+    header['EDGENPIX'] = (int(chosen_n), 'Edge-bias mask pixel count')
+    header['EDGEDMIN'] = (dmin, 'Edge-bias min distance from fibre (px)')
+    header['EDGESRC']  = (edge_src, 'Edge-bias mask source')
+    logger.info(f"Edge-bias {bench}{side} {color}: subtracted {edge_dc:.2f} DN "
+                f"(src={edge_src}, n={chosen_n})")
+    return corrected, stats
+
+
+def _write_edge_qa_rows(qa_csv, science_file, primary_hdr, results):
+    """Append one edge-bias QA row per extension to ``qa_csv`` (driver-side).
+
+    Writing here (after ray.get) rather than inside the Ray workers avoids
+    concurrent-append races on the shared CSV. Logs both the stripes-only and
+    stripes+flat candidate levels so the two can be compared during refinement.
+    """
+    import csv
+    def _fmt(v):
+        return '' if v is None or (isinstance(v, float) and np.isnan(v)) else f"{v:.3f}"
+    ts = primary_hdr.get('DATE-OBS', primary_hdr.get('DATE', ''))
+    wth = primary_hdr.get('WTH-TEMP', '')
+    os.makedirs(os.path.dirname(qa_csv) or '.', exist_ok=True)
+    is_new = not os.path.exists(qa_csv)
+    with open(qa_csv, 'a', newline='') as fh:
+        w = csv.writer(fh)
+        if is_new:
+            w.writerow(['timestamp', 'science_file', 'camera', 'bench', 'side', 'color',
+                        'edge_dc', 'edge_npix', 'level_stripes', 'level_stripes_plus_flat',
+                        'edge_src', 'wth_temp'])
+        for r in results:
+            if not r:
+                continue
+            st = r.get('edge_stats')
+            if not st:
+                continue
+            cam = f"{st['color']}{st['bench']}{st['side']}"
+            w.writerow([ts, os.path.basename(str(science_file)), cam,
+                        st['bench'], st['side'], st['color'],
+                        _fmt(st['edge_dc']), st['edge_npix'],
+                        _fmt(st['level_stripes']), _fmt(st['level_combined']),
+                        st['edge_src'], wth])
+
+
 @ray.remote
-def process_trace(hdu_data, header, trace_file, hdu_index, method='optimal', use_bias=None, remove_cosmic_rays=True):
+def process_trace(hdu_data, header, trace_file, hdu_index, method='optimal', use_bias=None,
+                  remove_cosmic_rays=True, edge_bias=None):
     """
     Process a single HDU: subtract bias, load the trace from a trace file, and create an ExtractLlamas object.
 
@@ -313,6 +439,13 @@ def process_trace(hdu_data, header, trace_file, hdu_index, method='optimal', use
             header['BIASSRC'] = (bias.header.get('BIASSRC', 'master_bias'), 'Source of bias subtracted')
             header['BIASLVL'] = (float(np.nanmedian(bias_data)), 'Median bias level subtracted (DN)')
 
+        # --- Per-frame edge-bias (DC offset) correction, on top of master bias ---
+        # Measures the residual DC level from unilluminated pixels of THIS frame and
+        # subtracts it, tracking the nightly temperature drift the static master bias
+        # cannot. No-op (records EDGESRC) when disabled or on placeholder extensions.
+        bias_subtracted_data, edge_stats = _apply_edge_bias(
+            bias_subtracted_data, tracer, header, bench, side, color, edge_bias)
+
         # Cosmic ray removal (after bias subtraction, before extraction)
         cr_mask = None
         if remove_cosmic_rays:
@@ -337,12 +470,14 @@ def process_trace(hdu_data, header, trace_file, hdu_index, method='optimal', use
             'extraction': extraction,
             'detector_background': detector_background,
             'hdu_index': hdu_index,
-            'cr_mask': cr_mask
+            'cr_mask': cr_mask,
+            'edge_stats': edge_stats
         }
     except Exception as e:
         logger.error(f"Error extracting trace from {trace_file}")
         logger.error(traceback.format_exc())
-        return {'extraction': None, 'detector_background': None, 'hdu_index': hdu_index, 'cr_mask': None}
+        return {'extraction': None, 'detector_background': None, 'hdu_index': hdu_index,
+                'cr_mask': None, 'edge_stats': None}
 
 
 def make_writable(extraction_obj):
@@ -427,7 +562,8 @@ def compute_detector_background(data, rows=(30, 50)):
 def GUI_extract(file: fits.BinTableHDU, flatfiles: str = None, output_dir: str = None,
                 slow_bias: str = None, fast_bias: str = None,
                 method='optimal', trace_dir=None, mastercalib_trace_dir=None,
-                remove_cosmic_rays=True, mask_output_dir=None, force_refresh=False) -> None:
+                remove_cosmic_rays=True, mask_output_dir=None, force_refresh=False,
+                edge_bias=None) -> None:
 
     """
     Extracts data from a FITS file using calibration files and saves the extracted data.
@@ -613,13 +749,23 @@ def GUI_extract(file: fits.BinTableHDU, flatfiles: str = None, output_dir: str =
             hdr = hdu[hdu_index].header
 
             if (method == 'optimal'):
-                future = extract_fn.remote(hdu_data, hdr, trace_file, hdu_index, method='optimal', use_bias=masterbiasfile, remove_cosmic_rays=remove_cosmic_rays)
+                future = extract_fn.remote(hdu_data, hdr, trace_file, hdu_index, method='optimal', use_bias=masterbiasfile, remove_cosmic_rays=remove_cosmic_rays, edge_bias=edge_bias)
             elif (method == 'boxcar'):
-                future = extract_fn.remote(hdu_data, hdr, trace_file, hdu_index, method='boxcar', use_bias=masterbiasfile, remove_cosmic_rays=remove_cosmic_rays)
+                future = extract_fn.remote(hdu_data, hdr, trace_file, hdu_index, method='boxcar', use_bias=masterbiasfile, remove_cosmic_rays=remove_cosmic_rays, edge_bias=edge_bias)
             futures.append(future)
 
         # Wait for all remote tasks to complete
         results = ray.get(futures)
+
+        # Edge-bias QA CSV (driver-side, race-free). Logged whenever a qa_csv path
+        # is supplied, regardless of whether Tier 2 is on, so both candidate levels
+        # can be compared over the night.
+        try:
+            _eb = edge_bias or {}
+            if _eb.get('qa_csv') and _eb.get('enabled', True):
+                _write_edge_qa_rows(_eb['qa_csv'], file, primary_hdr, results)
+        except Exception as _qa_exc:
+            logger.warning(f"Edge-bias QA logging failed: {_qa_exc}")
 
         # First, make all extraction objects writable (Ray returns read-only objects)
         writable_results = []

--- a/llamas_pyjamas/Utils/reduxSetupGUI.py
+++ b/llamas_pyjamas/Utils/reduxSetupGUI.py
@@ -1,0 +1,770 @@
+"""
+Interactive setup GUI for building a llamas-pyjamas reduction config file.
+
+Scans a raw LLAMAS data directory, tabulates the primary-header metadata of
+every MEF exposure (skipping whitelight and difference images), displays the
+observer's notes from obslog_usernotes.txt, and lets the user assign files to
+pipeline roles (red/green/blue lamp flats, twilight flat, science frames, raw
+bias frames). Selected raw biases are median-combined into master bias files
+with BiasLlamas, and a ready-to-run config file is generated from the package
+template (example_config.txt) with the chosen paths substituted in.
+
+Usage:
+    python -m llamas_pyjamas.Utils.reduxSetupGUI [data_dir] [-o config_out.txt]
+"""
+
+import argparse
+import os
+import re
+import shutil
+import sys
+import traceback
+from glob import glob
+
+from astropy.io import fits
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+import llamas_pyjamas
+from llamas_pyjamas.Bias.llamasBias import BiasLlamas
+
+TEMPLATE_PATH = os.path.join(os.path.dirname(llamas_pyjamas.__file__), 'example_config.txt')
+
+# Friendly labels for the PRODCATG header values
+PRODCATG_LABELS = {
+    'CAL.R-BIA': 'Bias',
+    'CAL.R-DRK': 'Dark',
+    'CAL.R-FLT': 'Flat',
+    'CAL.R-SKY': 'SkyFlat',
+    'CAL.R-ARC': 'Arc',
+    'SCI.R-SL': 'Science',
+    'SCI.R-DT': 'Science (dither)',
+}
+
+# Role definitions: key -> (display label, multi-file?, row tint, text color)
+BLACK = QtGui.QColor('black')
+ROLES = {
+    'red_flat': ('Red Flat', False, QtGui.QColor(255, 200, 200), BLACK),
+    'green_flat': ('Green Flat', False, QtGui.QColor(200, 240, 200), BLACK),
+    'blue_flat': ('Blue Flat', False, QtGui.QColor(200, 215, 255), BLACK),
+    'red_twilight': ('Red Twilight', False, QtGui.QColor(255, 224, 214), BLACK),
+    'green_twilight': ('Green Twilight', False, QtGui.QColor(220, 245, 220), BLACK),
+    'blue_twilight': ('Blue Twilight', False, QtGui.QColor(221, 231, 255), BLACK),
+    'red_arc': ('Red Arc', False, QtGui.QColor(248, 173, 173), BLACK),
+    'green_arc': ('Green Arc', False, QtGui.QColor(168, 226, 168), BLACK),
+    'blue_arc': ('Blue Arc', False, QtGui.QColor(173, 196, 250), BLACK),
+    'science': ('Science', True, QtGui.QColor(230, 205, 250), BLACK),
+    'bias': ('Bias', True, QtGui.QColor(212, 212, 212), BLACK),
+    'bad': ('BAD', True, QtGui.QColor(90, 90, 90), QtGui.QColor('white')),
+}
+
+NOTES_FILENAME = 'obslog_usernotes.txt'
+
+# Config keys that map 1:1 onto single-file roles
+KEY_TO_ROLE = {
+    'red_flat_file': 'red_flat',
+    'green_flat_file': 'green_flat',
+    'blue_flat_file': 'blue_flat',
+    'red_twilight_flat': 'red_twilight',
+    'green_twilight_flat': 'green_twilight',
+    'blue_twilight_flat': 'blue_twilight',
+    'red_arc_file': 'red_arc',
+    'green_arc_file': 'green_arc',
+    'blue_arc_file': 'blue_arc',
+}
+
+ARC_HEADER = '# WAVELENGTH CALIBRATION EXPOSURES (selected in the setup GUI)'
+BAD_HEADER = '# Exposures flagged as BAD data in the setup GUI (for the record; unused):'
+
+
+def parse_config(path):
+    """Parse a config file into (key -> value string, list of bad-flagged paths).
+
+    Same line format as reduce.py's loader; '#bad:' lines written by this GUI
+    are returned separately.
+    """
+    config, bad = {}, []
+    with open(path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith('#bad:'):
+                bad.append(line[len('#bad:'):].strip())
+            elif line and not line.startswith('#') and '=' in line:
+                key, value = line.split('=', 1)
+                config[key.strip()] = value.strip()
+    return config, bad
+
+
+def scan_directory(data_dir, progress_callback=None):
+    """Read primary headers of all relevant MEF files in data_dir.
+
+    Skips filenames containing 'white' or 'diff'. Returns a list of dicts with
+    keys: path, filename, object, exptime, type, comment, readmode. Files whose
+    headers cannot be read are returned with type 'ERR' rather than raised.
+    """
+    files = sorted(glob(os.path.join(data_dir, '*.fits')))
+    files = [f for f in files
+             if 'white' not in os.path.basename(f).lower()
+             and 'diff' not in os.path.basename(f).lower()]
+    entries = []
+    for i, path in enumerate(files):
+        if progress_callback and not progress_callback(i, len(files), os.path.basename(path)):
+            break
+        entry = {'path': path, 'filename': os.path.basename(path), 'object': '',
+                 'exptime': None, 'type': '', 'comment': '', 'readmode': ''}
+        try:
+            hdr = fits.getheader(path, 0)
+            entry['object'] = str(hdr.get('OBJECT', '') or '')
+            exptime = hdr.get('SEXPTIME', hdr.get('REXPTIME'))
+            entry['exptime'] = float(exptime) if exptime is not None else None
+            prodcatg = str(hdr.get('PRODCATG', '') or '')
+            entry['type'] = PRODCATG_LABELS.get(prodcatg, prodcatg)
+            comment = hdr.get('OBS-CMNT')
+            entry['comment'] = '' if comment is None else str(comment)
+            entry['readmode'] = str(hdr.get('READ-MDE', '') or '')
+        except Exception as err:
+            entry['type'] = 'ERR'
+            entry['comment'] = f'header read failed: {err}'
+        entries.append(entry)
+    return entries
+
+
+def generate_config(assignments, output_dir, slow_bias=None, fast_bias=None,
+                    template_path=TEMPLATE_PATH):
+    """Build config-file text from a template.
+
+    assignments maps role key -> path (single roles) or list of paths
+    ('science', 'bias', 'bad'). Assigned keys are substituted in place;
+    unassigned flat / twilight / arc keys are commented out so the pipeline
+    falls back to its defaults. template_path may be a previously generated
+    config, in which case hand-edited parameters are preserved; existing
+    slow/fast_bias_file lines are kept when no replacement is supplied.
+    """
+    key_values = {
+        # singular twilight_flat is superseded by the per-colour keys;
+        # comment it out and let each colour fall back per the template rules
+        'twilight_flat': None,
+        'science_files': ', '.join(assignments.get('science', [])) or None,
+        'trace_output_dir': os.path.join(output_dir, 'traces'),
+        'extraction_output_dir': os.path.join(output_dir, 'extractions'),
+        'cube_output_dir': os.path.join(output_dir, 'cubes'),
+        'slow_bias_file': slow_bias,
+        'fast_bias_file': fast_bias,
+    }
+    for key, role in KEY_TO_ROLE.items():
+        key_values[key] = assignments.get(role)
+    preserve_if_unset = {'slow_bias_file', 'fast_bias_file'}
+
+    with open(template_path, 'r') as f:
+        lines = f.readlines()
+
+    out = []
+    substituted = set()
+    for line in lines:
+        # drop any bad-flag block from a previous GUI run; re-appended below
+        if line.startswith('#bad:') or line.rstrip('\n') == BAD_HEADER:
+            continue
+        m = re.match(r'^(#?)\s*([A-Za-z_][A-Za-z0-9_]*)\s*=', line)
+        if m and m.group(2) in key_values and m.group(2) not in substituted:
+            key = m.group(2)
+            substituted.add(key)
+            value = key_values[key]
+            if value is not None:
+                out.append(f'{key} = {value}\n')
+            elif not m.group(1) and key not in preserve_if_unset:
+                # active template line for an unassigned key: comment it out
+                out.append('#' + line)
+            else:
+                out.append(line)
+        else:
+            out.append(line)
+
+    # arcs assigned but absent from the template go in an appended section
+    new_arcs = {f'{c}_arc_file': assignments.get(f'{c}_arc') for c in ('red', 'green', 'blue')}
+    new_arcs = {k: v for k, v in new_arcs.items() if v and k not in substituted}
+    if new_arcs:
+        if not any(ARC_HEADER in line for line in out):
+            out.append('\n#==============================================================================\n'
+                       f'{ARC_HEADER}\n'
+                       '#==============================================================================\n'
+                       '# Per-colour arc keys are not yet consumed by the pipeline; for a new\n'
+                       '# wavelength solution set arc_file with generate_new_wavelength_soln = True.\n')
+        for key, path in new_arcs.items():
+            out.append(f'{key} = {path}\n')
+
+    if assignments.get('bad'):
+        out.append(f'\n{BAD_HEADER}\n')
+        for path in assignments['bad']:
+            out.append(f'#bad: {path}\n')
+
+    return ''.join(out)
+
+
+def combine_biases(bias_files_by_mode, output_dir, progress_callback=None):
+    """Median-combine raw bias frames into master bias files per readout mode.
+
+    bias_files_by_mode maps 'SLOW'/'FAST' -> list of raw MEF paths. Returns a
+    dict mode -> path of the written {slow,fast}_master_bias.fits.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    outputs = {}
+    for mode, files in bias_files_by_mode.items():
+        if progress_callback:
+            progress_callback(f'Combining {len(files)} {mode} bias frames...')
+        bl = BiasLlamas(files)
+        bl.bias_path = output_dir
+        bl.master_bias()
+        combined = os.path.join(output_dir, 'combined_bias.fits')
+        final = os.path.join(output_dir, f'{mode.lower()}_master_bias.fits')
+        shutil.move(combined, final)
+        outputs[mode] = final
+    return outputs
+
+
+class BiasWorker(QtCore.QThread):
+    """Runs the bias combination off the GUI thread."""
+    status = QtCore.pyqtSignal(str)
+    finished_ok = QtCore.pyqtSignal(dict)
+    failed = QtCore.pyqtSignal(str)
+
+    def __init__(self, bias_files_by_mode, output_dir, parent=None):
+        super().__init__(parent)
+        self.bias_files_by_mode = bias_files_by_mode
+        self.output_dir = output_dir
+
+    def run(self):
+        try:
+            outputs = combine_biases(self.bias_files_by_mode, self.output_dir,
+                                     progress_callback=self.status.emit)
+            self.finished_ok.emit(outputs)
+        except Exception:
+            self.failed.emit(traceback.format_exc())
+
+
+class ReduxSetupWindow(QtWidgets.QMainWindow):
+
+    COL_FILE, COL_OBJ, COL_EXP, COL_TYPE, COL_READ, COL_CMNT, COL_ROLE = range(7)
+
+    def __init__(self, data_dir=None, config_out=None):
+        super().__init__()
+        self.setWindowTitle('LLAMAS Reduction Setup')
+        self.resize(1250, 850)
+        self.entries = []
+        self.roles = {}        # path -> set of role keys
+        self.prior_bias = {}   # READ-MDE -> master bias path from a loaded config
+        self._loaded_config_path = None
+        self._bias_worker = None
+        self._ds9 = None
+        self._build_ui()
+        if config_out:
+            self.configEdit.setText(os.path.abspath(config_out))
+        if data_dir:
+            self.dirEdit.setText(os.path.abspath(data_dir))
+            self.load_directory()
+
+    # ------------------------------------------------------------------ UI
+    def _build_ui(self):
+        central = QtWidgets.QWidget()
+        self.setCentralWidget(central)
+        vbox = QtWidgets.QVBoxLayout(central)
+
+        # Top bar: data directory
+        top = QtWidgets.QHBoxLayout()
+        top.addWidget(QtWidgets.QLabel('Data directory:'))
+        self.dirEdit = QtWidgets.QLineEdit()
+        top.addWidget(self.dirEdit, stretch=1)
+        browseBtn = QtWidgets.QPushButton('Browse…')
+        browseBtn.clicked.connect(self.browse_directory)
+        top.addWidget(browseBtn)
+        rescanBtn = QtWidgets.QPushButton('Rescan')
+        rescanBtn.clicked.connect(self.load_directory)
+        top.addWidget(rescanBtn)
+        vbox.addLayout(top)
+
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
+        vbox.addWidget(splitter, stretch=1)
+
+        # Observation table
+        tableBox = QtWidgets.QWidget()
+        tableLayout = QtWidgets.QVBoxLayout(tableBox)
+        tableLayout.setContentsMargins(0, 0, 0, 0)
+        self.table = QtWidgets.QTableWidget(0, 7)
+        self.table.setHorizontalHeaderLabels(
+            ['Filename', 'Object', 'Exp (s)', 'Type', 'Readout', 'Observer Comments', 'Role'])
+        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.table.setSortingEnabled(True)
+        header = self.table.horizontalHeader()
+        header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
+        header.setStretchLastSection(False)
+        self.table.setColumnWidth(self.COL_FILE, 330)
+        self.table.setColumnWidth(self.COL_OBJ, 180)
+        self.table.setColumnWidth(self.COL_EXP, 70)
+        self.table.setColumnWidth(self.COL_TYPE, 110)
+        self.table.setColumnWidth(self.COL_READ, 70)
+        self.table.setColumnWidth(self.COL_CMNT, 300)
+        self.table.setColumnWidth(self.COL_ROLE, 110)
+        self.table.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
+        self.table.customContextMenuRequested.connect(self.table_context_menu)
+        tableLayout.addWidget(self.table)
+
+        # Assignment buttons: colors across, calibration type down, plus the
+        # multi-file roles stacked alongside to keep the panel compact.
+        def role_button(role, text):
+            _label, _multi, color, fg = ROLES[role]
+            btn = QtWidgets.QPushButton(text)
+            btn.setStyleSheet(f'background-color: {color.name()}; color: {fg.name()};')
+            btn.clicked.connect(lambda _checked, r=role: self.assign_role(r))
+            return btn
+
+        btnRow = QtWidgets.QHBoxLayout()
+        calGrid = QtWidgets.QGridLayout()
+        calGrid.addWidget(QtWidgets.QLabel('Assign selection as:'), 0, 0)
+        for col, color in enumerate(('Red', 'Green', 'Blue'), start=1):
+            hdr = QtWidgets.QLabel(color)
+            hdr.setAlignment(QtCore.Qt.AlignmentFlag.AlignHCenter)
+            calGrid.addWidget(hdr, 0, col)
+        for row, (kind, suffix) in enumerate(
+                [('Flat', 'flat'), ('Twilight', 'twilight'), ('Arc', 'arc')], start=1):
+            calGrid.addWidget(QtWidgets.QLabel(kind), row, 0)
+            for col, color in enumerate(('red', 'green', 'blue'), start=1):
+                calGrid.addWidget(role_button(f'{color}_{suffix}', color.capitalize()), row, col)
+        btnRow.addLayout(calGrid)
+        btnRow.addSpacing(25)
+
+        miscGrid = QtWidgets.QGridLayout()
+        miscGrid.addWidget(role_button('science', 'Science'), 0, 0)
+        miscGrid.addWidget(role_button('bias', 'Bias'), 1, 0)
+        miscGrid.addWidget(role_button('bad', 'Flag Bad'), 0, 1)
+        clearBtn = QtWidgets.QPushButton('Clear Role')
+        clearBtn.clicked.connect(self.clear_role)
+        miscGrid.addWidget(clearBtn, 1, 1)
+        btnRow.addLayout(miscGrid)
+        btnRow.addStretch(1)
+        tableLayout.addLayout(btnRow)
+        splitter.addWidget(tableBox)
+
+        # Observer notes pane
+        notesBox = QtWidgets.QWidget()
+        notesLayout = QtWidgets.QVBoxLayout(notesBox)
+        notesLayout.setContentsMargins(0, 0, 0, 0)
+        notesLayout.addWidget(QtWidgets.QLabel('Observer notes (obslog_usernotes.txt):'))
+        self.notesView = QtWidgets.QPlainTextEdit()
+        self.notesView.setReadOnly(True)
+        notesLayout.addWidget(self.notesView)
+        splitter.addWidget(notesBox)
+        splitter.setSizes([600, 200])
+
+        # Bottom bar: outputs and config write
+        form = QtWidgets.QGridLayout()
+        form.addWidget(QtWidgets.QLabel('Output directory:'), 0, 0)
+        self.outdirEdit = QtWidgets.QLineEdit()
+        form.addWidget(self.outdirEdit, 0, 1)
+        outBrowse = QtWidgets.QPushButton('Browse…')
+        outBrowse.clicked.connect(self.browse_outdir)
+        form.addWidget(outBrowse, 0, 2)
+        form.addWidget(QtWidgets.QLabel('Config file:'), 1, 0)
+        self.configEdit = QtWidgets.QLineEdit()
+        form.addWidget(self.configEdit, 1, 1)
+        loadBtn = QtWidgets.QPushButton('Load Config')
+        loadBtn.clicked.connect(self.load_config_clicked)
+        form.addWidget(loadBtn, 1, 2)
+        self.writeBtn = QtWidgets.QPushButton('Write Config')
+        self.writeBtn.clicked.connect(self.write_config)
+        form.addWidget(self.writeBtn, 1, 3)
+        vbox.addLayout(form)
+
+        self.summaryLabel = QtWidgets.QLabel()
+        vbox.addWidget(self.summaryLabel)
+        self.update_summary()
+
+    # ------------------------------------------------------- directory scan
+    def browse_directory(self):
+        d = QtWidgets.QFileDialog.getExistingDirectory(
+            self, 'Select LLAMAS data directory', self.dirEdit.text() or os.path.expanduser('~'))
+        if d:
+            self.dirEdit.setText(d)
+            self.load_directory()
+
+    def browse_outdir(self):
+        d = QtWidgets.QFileDialog.getExistingDirectory(
+            self, 'Select output directory', self.outdirEdit.text() or self.dirEdit.text())
+        if d:
+            self.outdirEdit.setText(d)
+
+    def load_directory(self):
+        data_dir = self.dirEdit.text().strip()
+        if not os.path.isdir(data_dir):
+            QtWidgets.QMessageBox.warning(self, 'LLAMAS Setup',
+                                          f'Not a directory:\n{data_dir}')
+            return
+        progress = QtWidgets.QProgressDialog('Reading headers…', 'Cancel', 0, 100, self)
+        progress.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        progress.setMinimumDuration(0)
+
+        def cb(i, n, name):
+            progress.setMaximum(n)
+            progress.setValue(i)
+            progress.setLabelText(f'Reading headers… {name}')
+            QtWidgets.QApplication.processEvents()
+            return not progress.wasCanceled()
+
+        self.entries = scan_directory(data_dir, progress_callback=cb)
+        progress.close()
+        self.roles = {}
+        self.populate_table()
+        self.load_notes(data_dir)
+        if not self.outdirEdit.text().strip():
+            self.outdirEdit.setText(os.path.join(data_dir, 'reduced'))
+        if not self.configEdit.text().strip():
+            self.configEdit.setText(os.path.join(data_dir, 'llamas_redux_config.txt'))
+        self.update_summary()
+        # pick up a previous session's config so the user can revise it
+        config_path = self.configEdit.text().strip()
+        if os.path.isfile(config_path):
+            self.load_config(config_path)
+
+    def load_notes(self, data_dir):
+        notes_path = os.path.join(data_dir, NOTES_FILENAME)
+        if os.path.isfile(notes_path):
+            try:
+                with open(notes_path, 'r', errors='replace') as f:
+                    self.notesView.setPlainText(f.read())
+                return
+            except Exception as err:
+                self.notesView.setPlainText(f'(could not read {NOTES_FILENAME}: {err})')
+                return
+        self.notesView.setPlainText(f'(no {NOTES_FILENAME} found in {data_dir})')
+
+    def populate_table(self):
+        self.table.setSortingEnabled(False)
+        self.table.setRowCount(len(self.entries))
+        for row, e in enumerate(self.entries):
+            fileItem = QtWidgets.QTableWidgetItem(e['filename'])
+            fileItem.setData(QtCore.Qt.ItemDataRole.UserRole, e['path'])
+            self.table.setItem(row, self.COL_FILE, fileItem)
+            self.table.setItem(row, self.COL_OBJ, QtWidgets.QTableWidgetItem(e['object']))
+            expItem = QtWidgets.QTableWidgetItem()
+            if e['exptime'] is not None:
+                expItem.setData(QtCore.Qt.ItemDataRole.DisplayRole, round(e['exptime'], 3))
+            self.table.setItem(row, self.COL_EXP, expItem)
+            self.table.setItem(row, self.COL_TYPE, QtWidgets.QTableWidgetItem(e['type']))
+            self.table.setItem(row, self.COL_READ, QtWidgets.QTableWidgetItem(e['readmode']))
+            self.table.setItem(row, self.COL_CMNT, QtWidgets.QTableWidgetItem(e['comment']))
+            self.table.setItem(row, self.COL_ROLE, QtWidgets.QTableWidgetItem(''))
+        self.table.setSortingEnabled(True)
+
+    # ----------------------------------------------------------- ds9 link
+    def table_context_menu(self, pos):
+        row = self.table.rowAt(pos.y())
+        if row < 0:
+            return
+        path = self.table.item(row, self.COL_FILE).data(QtCore.Qt.ItemDataRole.UserRole)
+        menu = QtWidgets.QMenu(self)
+        actHere = menu.addAction('Display in ds9 (MEF cube)')
+        actNew = menu.addAction('Display in ds9 (new frame)')
+        action = menu.exec(self.table.viewport().mapToGlobal(pos))
+        if action is actHere:
+            self.send_to_ds9(path, new_frame=False)
+        elif action is actNew:
+            self.send_to_ds9(path, new_frame=True)
+
+    def send_to_ds9(self, path, new_frame=False):
+        """Load a MEF file into ds9 as a multi-extension cube via XPA."""
+        try:
+            import warnings
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')   # pyds9 warns if it can't find the app
+                import pyds9
+        except ImportError:
+            QtWidgets.QMessageBox.warning(
+                self, 'LLAMAS Setup',
+                'The pyds9 package is required to talk to ds9:\n    pip install pyds9')
+            return
+        QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.CursorShape.WaitCursor)
+        try:
+            if self._ds9 is None:
+                self._ds9 = pyds9.DS9()   # attaches to a running ds9
+            if new_frame:
+                self._ds9.set('frame new')
+            self._ds9.set(f'file mecube "{path}"')
+            self._ds9.set('scale zscale')
+            self.statusBar().showMessage(f'Sent to ds9: {os.path.basename(path)}')
+        except Exception as err:
+            self._ds9 = None   # stale connection; retry fresh next time
+            QtWidgets.QMessageBox.warning(
+                self, 'LLAMAS Setup',
+                f'Could not send to ds9 — is SAOImage ds9 running?\n\n{err}')
+        finally:
+            QtWidgets.QApplication.restoreOverrideCursor()
+
+    # ---------------------------------------------------------- role logic
+    def selected_paths(self):
+        paths = []
+        for idx in self.table.selectionModel().selectedRows(self.COL_FILE):
+            item = self.table.item(idx.row(), self.COL_FILE)
+            paths.append(item.data(QtCore.Qt.ItemDataRole.UserRole))
+        return paths
+
+    def assign_role(self, role):
+        paths = self.selected_paths()
+        if not paths:
+            QtWidgets.QMessageBox.information(self, 'LLAMAS Setup',
+                                              'Select one or more rows first.')
+            return
+        label, multi = ROLES[role][:2]
+        if not multi:
+            if len(paths) > 1:
+                QtWidgets.QMessageBox.information(
+                    self, 'LLAMAS Setup',
+                    f'{label} takes a single file; select exactly one row.')
+                return
+            # single-file role: remove it from any previous holder
+            for roleset in self.roles.values():
+                roleset.discard(role)
+        for p in paths:
+            roleset = self.roles.setdefault(p, set())
+            if role == 'bad':
+                roleset.clear()   # bad data holds no other role
+            else:
+                roleset.discard('bad')
+            roleset.add(role)
+        self.refresh_role_column()
+        self.update_summary()
+
+    def clear_role(self):
+        for p in self.selected_paths():
+            self.roles.pop(p, None)
+        self.refresh_role_column()
+        self.update_summary()
+
+    def refresh_role_column(self):
+        default_bg = QtGui.QBrush()
+        default_fg = QtGui.QBrush()
+        for row in range(self.table.rowCount()):
+            path = self.table.item(row, self.COL_FILE).data(QtCore.Qt.ItemDataRole.UserRole)
+            # display in ROLES order; tint by the first role a file holds
+            held = [r for r in ROLES if r in self.roles.get(path, ())]
+            if held:
+                label = ', '.join(ROLES[r][0] for r in held)
+                _l, _m, color, fgcolor = ROLES[held[0]]
+                bg, fg = QtGui.QBrush(color), QtGui.QBrush(fgcolor)
+            else:
+                label, bg, fg = '', default_bg, default_fg
+            self.table.item(row, self.COL_ROLE).setText(label)
+            for col in range(self.table.columnCount()):
+                self.table.item(row, col).setBackground(bg)
+                self.table.item(row, col).setForeground(fg)
+
+    def current_assignments(self):
+        """Return dict role -> path (single roles) or list of paths (multi)."""
+        assignments = {'science': [], 'bias': [], 'bad': []}
+        for path in sorted(self.roles):
+            for role in self.roles[path]:
+                if ROLES[role][1]:
+                    assignments[role].append(path)
+                else:
+                    assignments[role] = path
+        return assignments
+
+    # ---------------------------------------------------------- config load
+    def load_config_clicked(self):
+        path = self.configEdit.text().strip()
+        if not os.path.isfile(path):
+            path, _f = QtWidgets.QFileDialog.getOpenFileName(
+                self, 'Select config file', self.dirEdit.text(), 'Config files (*.txt *.cfg);;All files (*)')
+            if not path:
+                return
+            self.configEdit.setText(path)
+        self.load_config(path, verbose=True)
+
+    def load_config(self, config_path, verbose=False):
+        """Map an existing config file's selections back onto table roles."""
+        try:
+            config, bad_paths = parse_config(config_path)
+        except Exception as err:
+            QtWidgets.QMessageBox.warning(self, 'LLAMAS Setup',
+                                          f'Could not read config:\n{config_path}\n{err}')
+            return
+
+        by_path = {e['path'] for e in self.entries}
+        by_name = {e['filename']: e['path'] for e in self.entries}
+
+        def resolve(p):
+            p = p.strip()
+            if p in by_path:
+                return p
+            return by_name.get(os.path.basename(p))
+
+        role_paths = {}
+        # singular twilight applies to all colours; per-colour keys override
+        if config.get('twilight_flat'):
+            for c in ('red', 'green', 'blue'):
+                role_paths[f'{c}_twilight'] = config['twilight_flat']
+        for key, role in KEY_TO_ROLE.items():
+            if config.get(key):
+                role_paths[role] = config[key]
+
+        self.roles = {}
+        unmatched = []
+        for role, p in role_paths.items():
+            rp = resolve(p)
+            if rp:
+                self.roles.setdefault(rp, set()).add(role)
+            else:
+                unmatched.append(f'{ROLES[role][0]}: {p}')
+        science = config.get('science_files', '')
+        for p in (x for x in science.split(',') if x.strip()):
+            rp = resolve(p)
+            if rp:
+                self.roles.setdefault(rp, set()).add('science')
+            else:
+                unmatched.append(f'Science: {p.strip()}')
+        for p in bad_paths:
+            rp = resolve(p)
+            if rp:
+                self.roles[rp] = {'bad'}
+            else:
+                unmatched.append(f'BAD: {p}')
+
+        # master bias paths can't map to raw frames; carry them through instead
+        self.prior_bias = {'SLOW': config.get('slow_bias_file'),
+                           'FAST': config.get('fast_bias_file')}
+        trace_dir = config.get('trace_output_dir', '')
+        if trace_dir:
+            self.outdirEdit.setText(os.path.dirname(trace_dir.rstrip(os.sep)))
+
+        self._loaded_config_path = config_path
+        self.refresh_role_column()
+        self.update_summary()
+        msg = f'Loaded selections from {config_path}'
+        if unmatched:
+            msg += '\n\nEntries not found in this data directory (left unassigned):\n' \
+                   + '\n'.join(unmatched)
+            QtWidgets.QMessageBox.information(self, 'LLAMAS Setup', msg)
+        elif verbose:
+            QtWidgets.QMessageBox.information(self, 'LLAMAS Setup', msg)
+        self.statusBar().showMessage(f'Loaded config: {config_path}')
+
+    def update_summary(self):
+        a = self.current_assignments()
+
+        def rgb(suffix):
+            return ' '.join(f"{c[0].upper()}{'✓' if a.get(f'{c}_{suffix}') else '–'}"
+                            for c in ('red', 'green', 'blue'))
+
+        readmode = {e['path']: (e['readmode'] or '').upper() for e in self.entries}
+        n_slow = sum(1 for p in a['bias'] if readmode.get(p) == 'SLOW')
+        n_fast = sum(1 for p in a['bias'] if readmode.get(p) == 'FAST')
+        self.summaryLabel.setText(
+            f"Assigned — Flats: {rgb('flat')}   Twilights: {rgb('twilight')}   "
+            f"Arcs: {rgb('arc')}   Science: {len(a['science'])}   "
+            f"Bias: {len(a['bias'])} ({n_slow} slow / {n_fast} fast)   Bad: {len(a['bad'])}")
+
+    # --------------------------------------------------------- config write
+    def write_config(self):
+        assignments = self.current_assignments()
+        if not assignments['science']:
+            QtWidgets.QMessageBox.warning(self, 'LLAMAS Setup',
+                                          'Select at least one science file.')
+            return
+        missing = [ROLES[r][0] for r in
+                   ('red_flat', 'green_flat', 'blue_flat',
+                    'red_twilight', 'green_twilight', 'blue_twilight')
+                   if not assignments.get(r)]
+        if not assignments['bias'] and not any(self.prior_bias.values()):
+            missing.append('Bias')
+        if missing:
+            reply = QtWidgets.QMessageBox.question(
+                self, 'LLAMAS Setup',
+                'No selection for: ' + ', '.join(missing) +
+                '.\nThe pipeline will fall back to its defaults for these.\n\nContinue?',
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No)
+            if reply != QtWidgets.QMessageBox.StandardButton.Yes:
+                return
+
+        output_dir = self.outdirEdit.text().strip()
+        config_path = self.configEdit.text().strip()
+        if not output_dir or not config_path:
+            QtWidgets.QMessageBox.warning(self, 'LLAMAS Setup',
+                                          'Set the output directory and config file path.')
+            return
+        # a config loaded this session is being revised on purpose; only
+        # prompt before clobbering a file whose contents were never shown
+        if os.path.exists(config_path) and config_path != self._loaded_config_path:
+            reply = QtWidgets.QMessageBox.question(
+                self, 'LLAMAS Setup', f'Overwrite existing file?\n{config_path}',
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No)
+            if reply != QtWidgets.QMessageBox.StandardButton.Yes:
+                return
+
+        if assignments['bias']:
+            by_mode = {}
+            readmode = {e['path']: e['readmode'] for e in self.entries}
+            for p in assignments['bias']:
+                by_mode.setdefault(readmode.get(p) or 'SLOW', []).append(p)
+            self.writeBtn.setEnabled(False)
+            self._bias_progress = QtWidgets.QProgressDialog(
+                'Combining bias frames…', None, 0, 0, self)
+            self._bias_progress.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+            self._bias_progress.setMinimumDuration(0)
+            self._bias_worker = BiasWorker(by_mode, output_dir, self)
+            self._bias_worker.status.connect(self._bias_progress.setLabelText)
+            self._bias_worker.finished_ok.connect(
+                lambda outputs: self._finish_config(assignments, output_dir, config_path, outputs))
+            self._bias_worker.failed.connect(self._bias_failed)
+            self._bias_worker.start()
+        else:
+            self._finish_config(assignments, output_dir, config_path, {})
+
+    def _bias_failed(self, message):
+        self._bias_progress.close()
+        self.writeBtn.setEnabled(True)
+        QtWidgets.QMessageBox.critical(self, 'LLAMAS Setup',
+                                       f'Bias combination failed:\n{message}')
+
+    def _finish_config(self, assignments, output_dir, config_path, bias_outputs):
+        if self._bias_worker is not None:
+            self._bias_progress.close()
+            self.writeBtn.setEnabled(True)
+            self._bias_worker = None
+        try:
+            os.makedirs(output_dir, exist_ok=True)
+            # rewrite an existing config in place so hand-edited parameters
+            # survive; otherwise start from the package template
+            template = config_path if os.path.isfile(config_path) else TEMPLATE_PATH
+            text = generate_config(assignments, output_dir,
+                                   slow_bias=bias_outputs.get('SLOW') or self.prior_bias.get('SLOW'),
+                                   fast_bias=bias_outputs.get('FAST') or self.prior_bias.get('FAST'),
+                                   template_path=template)
+            with open(config_path, 'w') as f:
+                f.write(text)
+        except Exception:
+            QtWidgets.QMessageBox.critical(self, 'LLAMAS Setup',
+                                           f'Failed to write config:\n{traceback.format_exc()}')
+            return
+        msg = f'Config written to:\n{config_path}'
+        if bias_outputs:
+            msg += '\n\nMaster bias files:\n' + '\n'.join(sorted(bias_outputs.values()))
+        QtWidgets.QMessageBox.information(self, 'LLAMAS Setup', msg)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='GUI to build a llamas-pyjamas reduction config from a raw data directory.')
+    parser.add_argument('data_dir', nargs='?', default=None,
+                        help='Directory of raw LLAMAS MEF files (browse dialog if omitted)')
+    parser.add_argument('-o', '--output', default=None,
+                        help='Path for the generated config file')
+    args = parser.parse_args()
+
+    app = QtWidgets.QApplication(sys.argv)
+    win = ReduxSetupWindow(data_dir=args.data_dir, config_out=args.output)
+    win.show()
+    if not args.data_dir:
+        win.browse_directory()
+    sys.exit(app.exec())
+
+
+if __name__ == '__main__':
+    main()

--- a/llamas_pyjamas/example_config.txt
+++ b/llamas_pyjamas/example_config.txt
@@ -48,6 +48,50 @@ remove_cosmic_rays = True
 # If not set, masks are saved to {extraction_output_dir}/masks/
 #mask_output_dir = /path/to/custom/mask/output
 
+#==============================================================================
+# EDGE BIAS (DC OFFSET) CORRECTION
+#==============================================================================
+# LLAMAS CCDs have no overscan region, and the per-channel bias DC level drifts
+# through the night with temperature. The afternoon master bias removes the 2D
+# fixed-pattern structure, but not this drift. This step measures a per-frame,
+# per-extension DC offset from UNILLUMINATED pixels of each science/flat frame
+# and subtracts it ON TOP of the master bias, levelling the red/green/blue
+# channels. Applied to every frame that is extracted (science + flats).
+#
+# Tier 1 (default ON): the offset is measured over the top/bottom stripes that
+# lie outside the fibre stack (pixels farther than edge_bias_min_distance from
+# any fibre), using a robust sigma-clipped median. Placeholder (missing-camera)
+# extensions are detected and skipped automatically.
+#
+# Master switch (default true). Set false to disable entirely.
+edge_bias_dc_correction = true
+# Distance in pixels from the nearest fibre for a pixel to count as an
+# unilluminated top/bottom stripe pixel (default 20).
+edge_bias_min_distance = 20
+# Minimum stripe-mask pixels required; below this the correction is skipped for
+# that extension (guards placeholders / odd geometry). Default 500.
+edge_bias_min_pixels = 500
+#
+# Tier 2 (default OFF, experimental): additionally include the dark left/right
+# dichroic-crossover / low-sensitivity zones. These vary per camera and per
+# fibre (valid-x is a function of y), so they are taken from a flat-derived,
+# per-pixel mask (flat/unillum_mask.fits, written during flat processing):
+# on-fibre pixels whose flat throughput is below edge_bias_flat_frac of that
+# fibre's own peak. Only meaningfully affects green/blue (red flats fill the
+# full detector). Turn on to A/B-test against Tier 1.
+#   NOTE: the flat mask is generated during flat processing, so enabling this on
+#   an already-reduced dataset requires re-running the flat stage (clobber = true).
+edge_bias_use_flat_mask = false
+# Flat-throughput fraction (of each fibre's peak) below which a pixel is treated
+# as unilluminated when building the flat mask (default 0.1).
+edge_bias_flat_frac = 0.1
+#
+# QA: every run writes {extraction_output_dir}/edge_bias_levels.csv with, per
+# extension, the subtracted offset (edge_dc) and BOTH candidate levels
+# (stripes-only and stripes+flat) plus WTH-TEMP and timestamp — so the nightly
+# drift and the two mask choices can be compared. Per-extension header keywords:
+# EDGEDC, EDGENPIX, EDGEDMIN, EDGESRC.
+
 #calibration files to include
 red_flat_file = /Users/slh/Library/CloudStorage/Box-Box/slhughes/testing_files/trace_flats/LLAMAS_2025-05-23T12_34_47.516_mef.fits
 green_flat_file = /Users/slh/Library/CloudStorage/Box-Box/slhughes/testing_files/trace_flats/LLAMAS_2025-05-23T12_27_47.585_mef.fits

--- a/llamas_pyjamas/example_config.txt
+++ b/llamas_pyjamas/example_config.txt
@@ -4,6 +4,24 @@
 #if files cannot be found or processed correctly then the pipeline defaults to the master calibration files
 
 #==============================================================================
+# RESUME / RE-RUN CONTROL
+#==============================================================================
+# By default the pipeline RESUMES: on a re-run it reuses any intermediate
+# products already on disk and only does the work that is missing. Each stage
+# checks for its own outputs and skips when they are present:
+#   - flat pixel maps (flat/pixel_maps.fits + flat/flat_smooth_models.fits)
+#   - per-science extraction + RSS generation (*_RSS_*.fits)
+#   - fibre-to-fibre flat correction (*_FF.fits)
+#   - sky-subtraction framework (*_FF_SKYSUB.fits)
+#   - cube construction (*_cube_*.fits)
+# So if a run fails late (e.g. only cube construction), re-running picks up from
+# where it left off instead of repeating the whole reduction.
+#
+# Set clobber = true to force EVERY stage (including trace regeneration) to run
+# from scratch, ignoring any existing products. Default: false.
+# clobber = false
+
+#==============================================================================
 # BIAS CALIBRATION
 #==============================================================================
 # The pipeline requires two pre-combined master bias FITS files — one for each

--- a/llamas_pyjamas/reduce.py
+++ b/llamas_pyjamas/reduce.py
@@ -412,7 +412,7 @@ def extract_flat_field(flat_file_dir, output_dir, slow_bias=None, fast_bias=None
 
 def run_extraction(science_file, output_dir, slow_bias=None, fast_bias=None,
                    trace_dir=None, mastercalib_trace_dir=None,
-                   remove_cosmic_rays=True, mask_output_dir=None):
+                   remove_cosmic_rays=True, mask_output_dir=None, edge_bias=None):
     """
     Run spectrum extraction with hybrid trace support.
 
@@ -425,6 +425,9 @@ def run_extraction(science_file, output_dir, slow_bias=None, fast_bias=None,
         mastercalib_trace_dir: Mastercalib trace directory (for placeholder extensions)
         remove_cosmic_rays: Enable L.A.Cosmic cosmic ray removal before extraction
         mask_output_dir: Output directory for cosmic ray mask FITS files
+        edge_bias: Optional dict controlling the per-frame edge-bias (DC offset)
+            correction (see build_edge_bias_config); forwarded to GUI_extract.
+            None => process_trace uses its built-in defaults (Tier 1 on).
 
     Returns:
         str: Path to extraction file
@@ -448,7 +451,8 @@ def run_extraction(science_file, output_dir, slow_bias=None, fast_bias=None,
                 trace_dir=trace_dir,
                 mastercalib_trace_dir=mastercalib_trace_dir,
                 remove_cosmic_rays=remove_cosmic_rays,
-                mask_output_dir=mask_output_dir
+                mask_output_dir=mask_output_dir,
+                edge_bias=edge_bias
             )
     else:
         assert os.path.exists(science_file), "Science file does not exist."
@@ -460,7 +464,8 @@ def run_extraction(science_file, output_dir, slow_bias=None, fast_bias=None,
             trace_dir=trace_dir,
             mastercalib_trace_dir=mastercalib_trace_dir,
             remove_cosmic_rays=remove_cosmic_rays,
-            mask_output_dir=mask_output_dir
+            mask_output_dir=mask_output_dir,
+            edge_bias=edge_bias
         )
 
     # GUI_extract returns just the basename; make it a full path
@@ -468,6 +473,24 @@ def run_extraction(science_file, output_dir, slow_bias=None, fast_bias=None,
         extraction_file_path = os.path.join(output_dir, extraction_file_path)
 
     return extraction_file_path
+
+
+def build_edge_bias_config(config, extraction_path, flat_field_dir=None):
+    """Assemble the edge-bias (per-frame DC offset) settings from the pipeline config.
+
+    Returns a small, Ray-serialisable dict consumed by GUI_extract/process_trace.
+    The DC offset is measured from unilluminated pixels of each frame and
+    subtracted on top of the master bias to track the nightly temperature drift.
+    """
+    return {
+        'enabled':       bool(config.get('edge_bias_dc_correction', True)),
+        'min_distance':  float(config.get('edge_bias_min_distance', 20)),
+        'min_pixels':    int(config.get('edge_bias_min_pixels', 500)),
+        'use_flat_mask': bool(config.get('edge_bias_use_flat_mask', False)),
+        'flat_frac':     float(config.get('edge_bias_flat_frac', 0.1)),
+        'flat_mask_dir': flat_field_dir or os.path.join(extraction_path, 'flat'),
+        'qa_csv':        os.path.join(extraction_path, 'edge_bias_levels.csv'),
+    }
 
 
 def _extract_sky_frame(sky_file, extraction_path, slow_bias, fast_bias, trace_dir,
@@ -503,7 +526,8 @@ def _extract_sky_frame(sky_file, extraction_path, slow_bias, fast_bias, trace_di
     extracted = run_extraction(
         sky_file, extraction_path, slow_bias=slow_bias, fast_bias=fast_bias,
         trace_dir=trace_dir, mastercalib_trace_dir=CALIB_DIR,
-        remove_cosmic_rays=remove_cosmic_rays, mask_output_dir=mask_output_dir)
+        remove_cosmic_rays=remove_cosmic_rays, mask_output_dir=mask_output_dir,
+        edge_bias=build_edge_bias_config(config, extraction_path))
     if not extracted:
         raise RuntimeError(f"Extraction of sky frame {sky_file} produced no output")
 
@@ -624,7 +648,7 @@ def resolve_twilight_files(config):
 def _process_flat_for_rss(flat_files, flat_pixel_maps, output_dir,
                           trace_dir, arc_dict_config,
                           timestamp, label='flat',
-                          slow_bias=None, fast_bias=None):
+                          slow_bias=None, fast_bias=None, edge_bias=None):
     """Apply pixel flat → extract → wavelength-calibrate → generate RSS for a flat frame.
 
     Used for both dome flats (fibre-flat RSS) and twilight flats.
@@ -677,7 +701,7 @@ def _process_flat_for_rss(flat_files, flat_pixel_maps, output_dir,
         pkl_basename = run_extraction(corr_file, output_dir,
                                       slow_bias=slow_bias, fast_bias=fast_bias,
                                       trace_dir=trace_dir, mastercalib_trace_dir=CALIB_DIR,
-                                      remove_cosmic_rays=False)
+                                      remove_cosmic_rays=False, edge_bias=edge_bias)
         if not pkl_basename:
             print(f"  WARNING: Extraction failed for {os.path.basename(corr_file)} — skipping")
             continue
@@ -711,7 +735,7 @@ def process_flat_field_calibration(red_flat, green_flat, blue_flat, trace_dir, o
                                   arc_calib_file=None, verbose=False, method='simple',
                                   filter_size=12, signal_thresholds=None,
                                   clip_range=(0.90, 1.10), use_bias=None,
-                                  saturation_threshold=None):
+                                  saturation_threshold=None, unillum_frac=0.1):
     """Generate flat field pixel maps for science frame correction.
 
     Args:
@@ -753,6 +777,7 @@ def process_flat_field_calibration(red_flat, green_flat, blue_flat, trace_dir, o
                 signal_thresholds=signal_thresholds,
                 clip_range=clip_range,
                 saturation_threshold=saturation_threshold,
+                unillum_frac=unillum_frac,
             )
         elif method == 'bspline':
             results = process_flat_field_complete(
@@ -1756,7 +1781,14 @@ def main(config_path):
         config['extraction_output_dir'] = extraction_path
     else:
         extraction_path = config['extraction_output_dir']
-    
+
+    # Per-frame edge-bias (DC offset) settings, threaded into every extraction so
+    # science and flats are corrected identically. See build_edge_bias_config.
+    edge_bias_cfg = build_edge_bias_config(config, extraction_path)
+    print(f"Edge-bias DC correction: enabled={edge_bias_cfg['enabled']}, "
+          f"min_distance={edge_bias_cfg['min_distance']}px, "
+          f"use_flat_mask={edge_bias_cfg['use_flat_mask']}")
+
     # Note: Pixel maps will be created in extractions/flat/ directory during flat field processing
     # No need to pre-create a separate pixel_maps directory
     try:
@@ -1964,6 +1996,7 @@ def main(config_path):
                 signal_thresholds=signal_thresholds,
                 clip_range=(clip_min, clip_max),
                 saturation_threshold=config.get('pixel_flat_saturation_threshold'),
+                unillum_frac=edge_bias_cfg['flat_frac'],
             )
 
             if flat_pixel_maps:
@@ -2030,6 +2063,7 @@ def main(config_path):
                     arc_dict_config=config.get('arcdict'),
                     timestamp=timestamp_ff, label='twilight',
                     slow_bias=slow_bias_file, fast_bias=fast_bias_file,
+                    edge_bias=edge_bias_cfg,
                 )
                 if twi_rss:
                     config['flat_rss_outputs'] = twi_rss
@@ -2060,6 +2094,7 @@ def main(config_path):
                         arc_dict_config=config.get('arcdict'),
                         timestamp=timestamp_ff, label='dome',
                         slow_bias=slow_bias_file, fast_bias=fast_bias_file,
+                        edge_bias=edge_bias_cfg,
                     )
                     if dome_rss:
                         config['flat_rss_outputs'] = dome_rss
@@ -2245,7 +2280,8 @@ def main(config_path):
                     trace_dir=final_trace_dir,              # User traces
                     mastercalib_trace_dir=CALIB_DIR,        # Mastercalib fallback
                     remove_cosmic_rays=remove_cosmic_rays,
-                    mask_output_dir=mask_output_dir
+                    mask_output_dir=mask_output_dir,
+                    edge_bias=edge_bias_cfg
                 )
                 print(f"Extraction completed for {os.path.basename(science_file)}. Output file: {extracted_basename}")
                 if extracted_basename:
@@ -2264,7 +2300,8 @@ def main(config_path):
                 trace_dir=final_trace_dir,                  # User traces
                 mastercalib_trace_dir=CALIB_DIR,            # Mastercalib fallback
                 remove_cosmic_rays=remove_cosmic_rays,
-                mask_output_dir=mask_output_dir
+                mask_output_dir=mask_output_dir,
+                edge_bias=edge_bias_cfg
             )
             print(f"Extraction completed. Used traces from {final_trace_dir} with mastercalib fallback. Output file: {extracted_basename}")
             if extracted_basename:
@@ -2393,9 +2430,9 @@ def main(config_path):
                         try:
                             noflat_extracted = run_extraction(
                                 orig_science, extraction_path,
-                                use_bias=config.get('bias_file'),
                                 trace_dir=final_trace_dir,
-                                mastercalib_trace_dir=CALIB_DIR
+                                mastercalib_trace_dir=CALIB_DIR,
+                                edge_bias=edge_bias_cfg
                             )
                             noflat_corr_dict, noflat_hdr = correct_wavelengths(
                                 noflat_extracted, soln=config.get('arcdict'))
@@ -2514,6 +2551,7 @@ def main(config_path):
                                 slow_bias_file,
                                 extraction_path,
                                 fast_bias=fast_bias_file,
+                                edge_bias=edge_bias_cfg,
                             )
                             merged_primary = twi.get('primary_header',
                                                      merged_primary)

--- a/llamas_pyjamas/reduce.py
+++ b/llamas_pyjamas/reduce.py
@@ -21,6 +21,7 @@ Example:
 """
 
 import os
+import re
 import argparse
 import pickle
 import traceback
@@ -1208,7 +1209,7 @@ def construct_cube(rss_files, output_dir, wavelength_range=None, dispersion=1.0,
                    use_crr=True, crr_config=None, parallel=False, cube_method='traditional',
                    cube_pixel_size=0.3, cube_fiber_pitch=0.75, cube_wave_sampling=1.0,
                    cube_radius=1.5, cube_min_weight=0.01, cube_grid_method='oversampled',
-                   name_suffix=''):
+                   name_suffix='', resume=False):
     """
     Construct IFU data cubes from RSS files using simple, traditional, or CRR method.
 
@@ -1287,6 +1288,20 @@ def construct_cube(rss_files, output_dir, wavelength_range=None, dispersion=1.0,
             print(f"Processing {channel} channel RSS file with base name: {base_name}")
         else:
             print(f"Processing RSS file (no specific channel detected): {base_name}")
+
+        # Resume: skip RSS files whose output cube already exists (set clobber=true
+        # to force a rebuild). The filename is deterministic from base_name/channel,
+        # so this is checked before any (expensive) construction.
+        if resume:
+            if channel:
+                _existing_cube = os.path.join(output_dir, f"{base_name}_cube_{channel}{name_suffix}.fits")
+            else:
+                _existing_cube = os.path.join(output_dir, f"{base_name}_cube{name_suffix}.fits")
+            if os.path.exists(_existing_cube):
+                print(f"  RESUME: cube already exists, skipping: {os.path.basename(_existing_cube)}")
+                logger.info(f"Resume: skipping existing cube {_existing_cube}")
+                cube_files.append(_existing_cube)
+                continue
 
         # Determine which method to use
         # CRR flag overrides cube_method for backward compatibility
@@ -1478,6 +1493,38 @@ def construct_cube(rss_files, output_dir, wavelength_range=None, dispersion=1.0,
     
     return cube_files
 
+
+def _science_stem(science_file):
+    """Return a stable identifier for a science exposure.
+
+    The stem is preserved as a substring through the whole per-file product
+    naming chain (``{stem}_mef_flat_corrected_extract_RSS_{color}[...]_FF.fits``),
+    so it can be used to detect on disk whether a given science file has already
+    been reduced. Strips the extension and a trailing ``_mef``.
+    """
+    base = os.path.splitext(os.path.basename(science_file))[0]
+    if base.endswith('_mef'):
+        base = base[:-len('_mef')]
+    return base
+
+
+def _has_rss_product(extraction_dir, stem):
+    """True if a base RSS product (pre fibre-flat) exists for ``stem``.
+
+    Matches ``*_RSS*.fits`` files that belong to this science stem but are not
+    themselves fibre-flat (``_FF``) products. Presence of the RSS means the
+    extraction -> wavelength-correction -> sky -> RSS-generation chain for this
+    file already completed.
+    """
+    if not os.path.isdir(extraction_dir):
+        return False
+    for f in os.listdir(extraction_dir):
+        if (stem in f and f.endswith('.fits')
+                and '_RSS' in f and '_FF' not in f):
+            return True
+    return False
+
+
 def main(config_path):
     """
     Main entry point for the data reduction pipeline.
@@ -1507,7 +1554,13 @@ def main(config_path):
                 key, value = line.split('=', 1)
                 key = key.strip()
                 value = value.strip()
-                
+
+                # Strip inline comments: a '#' preceded by whitespace begins a
+                # trailing comment (e.g. "0.3   # pixel size"). The required
+                # leading whitespace means a '#' that is part of a value or path
+                # is left intact.
+                value = re.split(r'\s+#', value, maxsplit=1)[0].strip()
+
                 # Handle quoted values
                 if value.startswith('"') and value.endswith('"') or value.startswith("'") and value.endswith("'"):
                     value = value[1:-1]  # Remove quotes
@@ -1531,6 +1584,20 @@ def main(config_path):
         
         
     print("Configuration:", config)
+
+    # Resume control: by default the pipeline reuses any intermediate products
+    # already on disk (flat pixel maps, per-science RSS/_FF products, cubes) and
+    # skips the stages that produced them, so a re-run only does the work that is
+    # actually missing. Set ``clobber = true`` in the config to force every stage
+    # to run from scratch (including trace regeneration; normally traces are also
+    # reused when ``use_existing_traces`` is true, which is the default).
+    clobber = bool(config.get('clobber', False))
+    resume = not clobber
+    if clobber:
+        print("clobber=True — all stages will run from scratch (no resume).")
+    else:
+        print("Resume enabled — existing intermediate products will be reused "
+              "(set clobber=true to force a full re-run).")
 
     # Configure pipeline logging — log file goes next to the config file
     if 'log_output_dir' in config:
@@ -1707,7 +1774,7 @@ def main(config_path):
         trace_source = None
 
         # Check if we should use existing traces or generate new ones
-        if config.get('use_existing_traces', True) and os.path.exists(config.get('trace_output_dir')):
+        if resume and config.get('use_existing_traces', True) and os.path.exists(config.get('trace_output_dir')):
             # Check if trace files exist in the specified directory
             import glob
             existing_traces = glob.glob(os.path.join(config.get('trace_output_dir'), '*.pkl'))
@@ -1842,7 +1909,25 @@ def main(config_path):
         # Generate flat field pixel maps if flat correction is enabled
         flat_pixel_maps = []
         flat_field_method = config.get('flat_field_method', 'simple')
-        if config.get('apply_flat_field_correction', True):
+        # Resume: flat_pixel_maps is always a single-element list holding the path
+        # to pixel_maps.fits (see process_flat_field_calibration). If both that MEF
+        # and the flat_smooth_models.fits (needed by the fibre-flat stage) already
+        # exist, we can skip the expensive flat extraction entirely and just point
+        # flat_pixel_maps at the existing file.
+        _flat_field_dir = config.get('flat_field_output_dir',
+                                     os.path.join(extraction_path, 'flat'))
+        _flat_products_present = (
+            os.path.exists(os.path.join(_flat_field_dir, 'pixel_maps.fits'))
+            and os.path.exists(os.path.join(_flat_field_dir, 'flat_smooth_models.fits')))
+        if config.get('apply_flat_field_correction', True) and resume and _flat_products_present:
+            print("\n" + "="*60)
+            print("FLAT FIELD PROCESSING — RESUME (existing products found)")
+            print("="*60)
+            print(f"Using existing pixel_maps.fits + flat_smooth_models.fits in {_flat_field_dir}")
+            print("Skipping flat field generation (set clobber=true to force).")
+            logger.info("Resume: skipping flat field generation (products present)")
+            flat_pixel_maps = [os.path.join(_flat_field_dir, 'pixel_maps.fits')]
+        elif config.get('apply_flat_field_correction', True):
             print("\n" + "="*60)
             print(f"FLAT FIELD PROCESSING (method={flat_field_method})")
             print("="*60)
@@ -2036,7 +2121,18 @@ def main(config_path):
                     
                     if not os.path.exists(science_file):
                         raise FileNotFoundError(f"Science file {science_file} does not exist.")
-                    
+
+                    # Resume: reuse the existing flat-corrected file if present, keeping
+                    # this list aligned with original_science_files for the extraction zip.
+                    _existing_corr = os.path.join(
+                        flat_output_dir,
+                        os.path.splitext(os.path.basename(science_file))[0] + '_flat_corrected.fits')
+                    if resume and os.path.exists(_existing_corr):
+                        print(f"RESUME: reusing existing flat-corrected file "
+                              f"{os.path.basename(_existing_corr)}")
+                        flat_corrected_files.append(_existing_corr)
+                        continue
+
                     corrected_file, stats = apply_flat_field_correction(
                         science_file,
                         flat_pixel_maps,
@@ -2063,25 +2159,33 @@ def main(config_path):
                 science_file = config['science_files']
                 if not os.path.exists(science_file):
                     raise FileNotFoundError(f"Science file {science_file} does not exist.")
-                
-                print(f"\nFlat-correcting science file: {os.path.basename(science_file)}")
-                corrected_file, stats = apply_flat_field_correction(
-                    science_file,
-                    flat_pixel_maps,
+
+                _existing_corr = os.path.join(
                     flat_output_dir,
-                    validate_matching=config.get('validate_flat_matching', True),
-                    require_all_matches=config.get('require_all_flat_matches', False)
-                )
-                
-                if corrected_file:
-                    science_files_to_process = corrected_file
-                    overall_stats['total_corrected'] = stats['corrected']
-                    overall_stats['total_skipped'] = stats['skipped']
-                    overall_stats['total_errors'] = stats['errors']
+                    os.path.splitext(os.path.basename(science_file))[0] + '_flat_corrected.fits')
+                if resume and os.path.exists(_existing_corr):
+                    print(f"RESUME: reusing existing flat-corrected file "
+                          f"{os.path.basename(_existing_corr)}")
+                    science_files_to_process = _existing_corr
                 else:
-                    print(f"ERROR: Failed to flat-correct {science_file}, using original")
-                    logger.error(f"Failed to flat-correct {science_file}, using original")
-                    science_files_to_process = science_file
+                    print(f"\nFlat-correcting science file: {os.path.basename(science_file)}")
+                    corrected_file, stats = apply_flat_field_correction(
+                        science_file,
+                        flat_pixel_maps,
+                        flat_output_dir,
+                        validate_matching=config.get('validate_flat_matching', True),
+                        require_all_matches=config.get('require_all_flat_matches', False)
+                    )
+
+                    if corrected_file:
+                        science_files_to_process = corrected_file
+                        overall_stats['total_corrected'] = stats['corrected']
+                        overall_stats['total_skipped'] = stats['skipped']
+                        overall_stats['total_errors'] = stats['errors']
+                    else:
+                        print(f"ERROR: Failed to flat-correct {science_file}, using original")
+                        logger.error(f"Failed to flat-correct {science_file}, using original")
+                        science_files_to_process = science_file
             
             print("\n" + "="*60)
             print("FLAT FIELD CORRECTION SUMMARY")
@@ -2123,6 +2227,14 @@ def main(config_path):
             logger.info(f"Stage: Extracting {len(science_files_to_process)} science files")
 
             for i, (science_file, orig_file) in enumerate(zip(science_files_to_process, original_science_files)):
+                # Resume: if this exposure already has an RSS product on disk, its
+                # whole extraction -> wavelength -> sky -> RSS chain is done. Skip it
+                # (not appending to science_pkl_pairs skips its post-processing too).
+                if resume and _has_rss_product(extraction_path, _science_stem(orig_file)):
+                    print(f"RESUME: RSS product already exists for "
+                          f"{os.path.basename(orig_file)} — skipping extraction/RSS.")
+                    logger.info(f"Resume: skipping extraction for {orig_file} (RSS present)")
+                    continue
                 print(f"Extracting science file {i+1}/{len(science_files_to_process)}: {os.path.basename(science_file)}")
                 # Process each science file with hybrid trace support
                 extracted_basename = run_extraction(
@@ -2138,6 +2250,10 @@ def main(config_path):
                 print(f"Extraction completed for {os.path.basename(science_file)}. Output file: {extracted_basename}")
                 if extracted_basename:
                     science_pkl_pairs.append((os.path.join(extraction_path, extracted_basename), orig_file))
+        elif resume and _has_rss_product(extraction_path, _science_stem(original_science_files[0])):
+            print(f"RESUME: RSS product already exists for "
+                  f"{os.path.basename(original_science_files[0])} — skipping extraction/RSS.")
+            logger.info(f"Resume: skipping extraction for {original_science_files[0]} (RSS present)")
         else:
             print(f"Extracting science file: {os.path.basename(science_files_to_process)}")
             extracted_basename = run_extraction(
@@ -2340,7 +2456,25 @@ def main(config_path):
             smooth_models_file = os.path.join(flat_field_dir,
                                               'flat_smooth_models.fits')
 
-            if os.path.exists(smooth_models_file):
+            # RSS files that still need a fibre-flat product. On resume, drop any
+            # that already have their _FF.fits so the (expensive) twilight
+            # reduction below is skipped entirely when nothing is pending.
+            _rss_all = [
+                os.path.join(extraction_path, f)
+                for f in os.listdir(extraction_path)
+                if f.endswith('.fits') and '_RSS' in f and '_FF' not in f
+            ]
+            if resume:
+                _rss_pending = [r for r in _rss_all
+                                if not os.path.exists(r.replace('.fits', '_FF.fits'))]
+            else:
+                _rss_pending = _rss_all
+
+            if os.path.exists(smooth_models_file) and not _rss_pending:
+                print("RESUME: all _FF products present — skipping fibre-to-fibre "
+                      "flat correction (set clobber=true to force).")
+                logger.info("Resume: skipping fibre-flat (all _FF present)")
+            elif os.path.exists(smooth_models_file):
                 print("\n" + "=" * 60)
                 print("FIBRE-TO-FIBRE FLAT CORRECTION")
                 print("=" * 60)
@@ -2453,14 +2587,8 @@ def main(config_path):
                         smooth_models_file, flat_field_dir)
                     print("Fibre flat computed (lamp-only method)")
 
-                # Apply to all RSS files in the extraction directory
-                rss_to_correct = [
-                    os.path.join(extraction_path, f)
-                    for f in os.listdir(extraction_path)
-                    if f.endswith('.fits') and '_RSS' in f
-                    and '_FF' not in f
-                ]
-                for rss_file in rss_to_correct:
+                # Apply to the pending RSS files (resume-filtered above).
+                for rss_file in _rss_pending:
                     ff_output = rss_file.replace('.fits', '_FF.fits')
                     apply_fibre_flat_to_rss(rss_file, corrections_file,
                                            ff_output)
@@ -2481,6 +2609,15 @@ def main(config_path):
                 for f in os.listdir(extraction_path)
                 if f.endswith('_FF.fits') and '_RSS' in f
             ]
+            # Resume: skip FF files that already have their _FF_SKYSUB.fits product.
+            if resume:
+                _sky_pending = [f for f in ff_for_sky
+                                if not os.path.exists(f.replace('_FF.fits', '_FF_SKYSUB.fits'))]
+                if ff_for_sky and not _sky_pending:
+                    print("RESUME: all _FF_SKYSUB products present — skipping sky framework "
+                          "(set clobber=true to force).")
+                    logger.info("Resume: skipping sky framework (all _FF_SKYSUB present)")
+                ff_for_sky = _sky_pending
             if ff_for_sky:
                 print("\n" + "=" * 60)
                 print("SKY-SUBTRACTION FRAMEWORK")
@@ -2537,6 +2674,7 @@ def main(config_path):
                 cube_min_weight=float(config.get('cube_min_weight', 0.01)),
                 cube_grid_method=config.get('cube_grid_method', 'oversampled'),
                 name_suffix=name_suffix,
+                resume=resume,
             )
 
         cube_files = []


### PR DESCRIPTION
Three tested additions on `test-overscan`. Clean fast-forward from `main` (no conflicts). All verified end-to-end against the may26/ut20260516_17 dataset.

## 1. Resume-by-default reruns + config parsing fix (88d85fa)
- Config parser now strips trailing inline comments (`key = 0.3  # ...`), fixing a `ValueError` when a commented numeric key (e.g. `cube_pixel_size`) hit `float()`. A `#` inside a path is preserved.
- Reductions now **resume by default**: each stage checks for its own products on disk and skips when present (flat pixel maps, per-science extraction/RSS, fibre-flat, sky, cubes), so a re-run only does the missing work. Set `clobber = true` to force a full from-scratch run.

## 2. Interactive reduction setup GUI (1e68576)

Created a new GUI for planning reductions of runs, this GUI outputs a configuration file in the standard llamas-pyjamas format, with filenames specific to the user's observing run.

- `Utils/reduxSetupGUI.py`: PyQt6 tool that scans a raw data directory, tabulates exposure headers + observer notes, lets the user assign files to pipeline roles, median-combines biases, and writes a ready-to-run config from the template.

## 3. Per-frame edge-bias (DC offset) correction (fa5722b)
- LLAMAS CCDs have no overscan; the per-channel bias DC level drifts with temperature through the night, leaving red/green/blue at different levels after the static master bias. This measures a per-extension DC offset from each frame's own unilluminated pixels and subtracts it **on top of** the master bias.
- **Tier 1 (default on):** sigma-clipped level over the top/bottom stripes outside the fibre stack (distance transform on the trace `fiberimg`); placeholders auto-skipped.
- **Tier 2 (default off):** additionally include flat-derived, per-pixel dichroic-dark L/R zones (`flat/unillum_mask.fits`).
- Config keys documented in `example_config.txt`; per-extension `EDGE*` headers + a QA CSV (`edge_bias_levels.csv`) logging both candidate levels and `WTH-TEMP` per frame.
- Verified: residual per-camera offsets of ~9–47 DN after master bias, placeholders skipped, QA artifacts written correctly.
- Also fixes a latent bug in the `noflat_comparison` path (passed an unsupported `use_bias=` kwarg to `run_extraction`).

Generated in collaboration with [Claude Code]